### PR TITLE
Added AdditionalFileExtensionsPlugin

### DIFF
--- a/Contrib/AdditionalFileExtensions/AdditionalFileExtensions.sln
+++ b/Contrib/AdditionalFileExtensions/AdditionalFileExtensions.sln
@@ -1,0 +1,20 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImageResizer.Plugins.AdditionalFileExtensions", "ImageResizer.Plugins.AdditionalFileExtensions\ImageResizer.Plugins.AdditionalFileExtensions.csproj", "{F9211405-186B-4478-B05A-3D2C0DAFAF14}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F9211405-186B-4478-B05A-3D2C0DAFAF14}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F9211405-186B-4478-B05A-3D2C0DAFAF14}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F9211405-186B-4478-B05A-3D2C0DAFAF14}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F9211405-186B-4478-B05A-3D2C0DAFAF14}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/Contrib/AdditionalFileExtensions/ImageResizer.Plugins.AdditionalFileExtensions/AdditionalFileExtensionsPlugin.cs
+++ b/Contrib/AdditionalFileExtensions/ImageResizer.Plugins.AdditionalFileExtensions/AdditionalFileExtensionsPlugin.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+
+namespace ImageResizer.Plugins.AdditionalFileExtensions
+{
+    /// <summary>
+    /// A plugin for registering additional file extensions to be handled by ImageResizer
+    /// </summary>
+    /// <example>
+    /// <add name="AdditionalFileExtensions" fileExtensions="ext1,ext2,ext3" />
+    /// </example>
+    public class AdditionalFileExtensionsPlugin : IPlugin, IFileExtensionPlugin
+    {
+        private const string FileExtensionsKey = "fileExtensions";
+        private readonly IEnumerable<string> fileExtensions;
+
+        public AdditionalFileExtensionsPlugin(NameValueCollection configuration)
+        {
+            if (configuration == null)
+                throw new ArgumentNullException("configuration");
+
+            fileExtensions = ParseFileExtensions(configuration);
+        }
+
+        public IEnumerable<string> GetSupportedFileExtensions()
+        {
+            return fileExtensions;
+        }
+
+        public IPlugin Install(Configuration.Config c)
+        {
+            c.Plugins.add_plugin(this);
+            return this;
+        }
+
+        public bool Uninstall(Configuration.Config c)
+        {
+            c.Plugins.remove_plugin(this);
+            return true;
+        }
+
+        private static IEnumerable<string> ParseFileExtensions(NameValueCollection collection)
+        {
+            var fileExtensionsString = collection.Get(FileExtensionsKey);
+
+            if (string.IsNullOrEmpty(fileExtensionsString))
+                return Enumerable.Empty<string>();
+
+            return fileExtensionsString.Split(',', ';', '|');
+        }
+    }
+}

--- a/Contrib/AdditionalFileExtensions/ImageResizer.Plugins.AdditionalFileExtensions/ImageResizer.Plugins.AdditionalFileExtensions.csproj
+++ b/Contrib/AdditionalFileExtensions/ImageResizer.Plugins.AdditionalFileExtensions/ImageResizer.Plugins.AdditionalFileExtensions.csproj
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{F9211405-186B-4478-B05A-3D2C0DAFAF14}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ImageResizer.Plugins.AdditionalFileExtensions</RootNamespace>
+    <AssemblyName>ImageResizer.Plugins.AdditionalFileExtensions</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="ImageResizer">
+      <HintPath>..\..\..\dlls\debug\ImageResizer.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AdditionalFileExtensionsPlugin.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Contrib/AdditionalFileExtensions/ImageResizer.Plugins.AdditionalFileExtensions/Properties/AssemblyInfo.cs
+++ b/Contrib/AdditionalFileExtensions/ImageResizer.Plugins.AdditionalFileExtensions/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ImageResizer.Plugins.AdditionalFileExtensions")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ImageResizer.Plugins.AdditionalFileExtensions")]
+[assembly: AssemblyCopyright("Copyright ©  2012")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("22aaeb48-3701-421d-a780-60dfd50d3f09")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
This plugin allows you to easily register additional file extensions to be handled by ImageResizer.

To configure set the following in web.config:

<add name="AdditionalFileExtensions" fileExtensions="ext1,ext2,ext3" />
