### PR TITLE
Fixed file exist check in VirtualFolder

### DIFF
--- a/Core/Plugins/Basic/VirtualFolder.cs
+++ b/Core/Plugins/Basic/VirtualFolder.cs
@@ -178,7 +178,7 @@ namespace ImageResizer.Plugins.Basic {
         private bool isOnlyVirtualPath(string virtualPath) {
             if (NoIOPermission) return false; //Don't act as a VPP if we don't have permission to operate.
             if (!IsVirtualPath(virtualPath)) return false;
-            if (File.Exists(VirtualToPhysical(virtualPath))) return false;
+            if (!File.Exists(VirtualToPhysical(virtualPath))) return false;
             if (registeredVpp && Previous.FileExists(virtualPath)) return false;
             return true;
         }


### PR DESCRIPTION
When file exists, returns false (would expect true) then a null stream is propagated through pipeline resulting in a null reference exception in disk cache.
In our case, the virtual path was an UNC path (e.g. \server\folder\file.jpg)
