### PR TITLE
Allow MongoDB connection string to be specified elsewhere

### DIFF
--- a/ImageResizer-WithTests.sln
+++ b/ImageResizer-WithTests.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.21005.1
+VisualStudioVersion = 12.0.30110.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{6BEFD728-E3C5-43CC-BA9E-292B7CA4429D}"
 	ProjectSection(SolutionItems) = preProject
@@ -131,6 +131,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImageResizer.Plugins.LicenseStore.Tests", "Tests\ImageResizer.Plugins.LicenseStore.Tests\ImageResizer.Plugins.LicenseStore.Tests.csproj", "{28494A7A-7B55-45A3-B06A-FA8A241DDCA4}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Imazen.WebP", "submodules\libwebp-net\Imazen.WebP\Imazen.WebP.csproj", "{92F607A3-2F04-4536-8346-B6FEF8B774FF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImageResizer.Plugins.MongoReader.Tests", "Tests\ImageResizer.Plugins.MongoReader.Tests\ImageResizer.Plugins.MongoReader.Tests.csproj", "{36EDFBE6-51E0-4E37-939E-1851CD37E341}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -1255,6 +1257,24 @@ Global
 		{92F607A3-2F04-4536-8346-B6FEF8B774FF}.Trial|Mixed Platforms.Build.0 = Release|Any CPU
 		{92F607A3-2F04-4536-8346-B6FEF8B774FF}.Trial|x64.ActiveCfg = Release|Any CPU
 		{92F607A3-2F04-4536-8346-B6FEF8B774FF}.Trial|x86.ActiveCfg = Release|Any CPU
+		{36EDFBE6-51E0-4E37-939E-1851CD37E341}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{36EDFBE6-51E0-4E37-939E-1851CD37E341}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{36EDFBE6-51E0-4E37-939E-1851CD37E341}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{36EDFBE6-51E0-4E37-939E-1851CD37E341}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{36EDFBE6-51E0-4E37-939E-1851CD37E341}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{36EDFBE6-51E0-4E37-939E-1851CD37E341}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{36EDFBE6-51E0-4E37-939E-1851CD37E341}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{36EDFBE6-51E0-4E37-939E-1851CD37E341}.Release|Any CPU.Build.0 = Release|Any CPU
+		{36EDFBE6-51E0-4E37-939E-1851CD37E341}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{36EDFBE6-51E0-4E37-939E-1851CD37E341}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{36EDFBE6-51E0-4E37-939E-1851CD37E341}.Release|x64.ActiveCfg = Release|Any CPU
+		{36EDFBE6-51E0-4E37-939E-1851CD37E341}.Release|x86.ActiveCfg = Release|Any CPU
+		{36EDFBE6-51E0-4E37-939E-1851CD37E341}.Trial|Any CPU.ActiveCfg = Release|Any CPU
+		{36EDFBE6-51E0-4E37-939E-1851CD37E341}.Trial|Any CPU.Build.0 = Release|Any CPU
+		{36EDFBE6-51E0-4E37-939E-1851CD37E341}.Trial|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{36EDFBE6-51E0-4E37-939E-1851CD37E341}.Trial|Mixed Platforms.Build.0 = Release|Any CPU
+		{36EDFBE6-51E0-4E37-939E-1851CD37E341}.Trial|x64.ActiveCfg = Release|Any CPU
+		{36EDFBE6-51E0-4E37-939E-1851CD37E341}.Trial|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Plugins/MongoReader/ImageResizer.Plugins.MongoReader.csproj
+++ b/Plugins/MongoReader/ImageResizer.Plugins.MongoReader.csproj
@@ -58,6 +58,7 @@
       <HintPath>..\..\Packages\mongocsharpdriver.1.8.3\lib\net35\MongoDB.Driver.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
   </ItemGroup>
   <ItemGroup>

--- a/Tests/ImageResizer.Plugins.MongoReader.Tests/App.config
+++ b/Tests/ImageResizer.Plugins.MongoReader.Tests/App.config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <connectionStrings>
+    <add name="MongoReader.ConnectionString.Empty" connectionString=""/>
+    <add name="MongoReader.ConnectionString.Name" connectionString="mongodb://server/database?from=connectionString"/>
+  </connectionStrings>
+  <appSettings>
+    <add key="MongoReader.ConnectionString.Key" value="mongodb://server/database?from=appSetting"/>
+  </appSettings>
+</configuration>

--- a/Tests/ImageResizer.Plugins.MongoReader.Tests/ConnectionStringTests.cs
+++ b/Tests/ImageResizer.Plugins.MongoReader.Tests/ConnectionStringTests.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Specialized;
+using MbUnit.Framework;
+
+namespace ImageResizer.Plugins.MongoReader.Tests
+{
+    [TestFixture]
+    public class TestMongoReader
+    {
+        [Test]
+        public void GetConnectionString_ShouldReturnConnectionString_WhenConnectionStringSpecified()
+        {
+            var expected = "test";
+            var args = new NameValueCollection
+            {
+                {"connectionString", expected}
+            };
+
+            var actual = MongoReaderPlugin.GetConnectionString(args);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void GetConnectionString_ShouldReturnConnectionString_WhenValidConnectionStringNameSpecified()
+        {
+            var expected = "mongodb://server/database?from=connectionString";
+            var args = new NameValueCollection
+            {
+                {"connectionStringName", "MongoReader.ConnectionString.Name"}
+            };
+
+            var actual = MongoReaderPlugin.GetConnectionString(args);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void GetConnectionString_ShouldThrowException_WhenInvalidConnectionStringNameSpecified()
+        {
+            var args = new NameValueCollection
+            {
+                {"connectionStringName", "MongoReader.ConnectionString.InvalidName"}
+            };
+
+            Assert.Throws<ApplicationException>(
+                () => MongoReaderPlugin.GetConnectionString(args),
+                "A connection string named \"{0}\" does not exist.",
+                "MongoReader.ConnectionString.InvalidName");
+        }
+
+        [Test]
+        public void GetConnectionString_ShouldThrowException_WhenValidConnectionStringNameSpecified_WithEmptyValue()
+        {
+            var args = new NameValueCollection
+            {
+                {"connectionStringName", "MongoReader.ConnectionString.Empty"}
+            };
+
+            Assert.Throws<ApplicationException>(
+                () => MongoReaderPlugin.GetConnectionString(args),
+                "A connection string named \"{0}\" does not exist.",
+                "MongoReader.ConnectionString.InvalidName");
+        }
+
+        [Test]
+        public void GetConnectionString_ShouldReturnConnectionString_WhenValidAppSettingKeySpecified()
+        {
+            var expected = "mongodb://server/database?from=appSetting";
+            var args = new NameValueCollection
+            {
+                {"connectionStringAppKey", "MongoReader.ConnectionString.Key"}
+            };
+
+            var actual = MongoReaderPlugin.GetConnectionString(args);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void GetConnectionString_ShouldThrowException_WhenInvalidConnectionStringAppKeySpecified()
+        {
+            var args = new NameValueCollection
+            {
+                {"connectionStringAppKey", "MongoReader.ConnectionString.InvalidKey"}
+            };
+
+            Assert.Throws<ApplicationException>(
+                () => MongoReaderPlugin.GetConnectionString(args),
+                "An app setting with key \"{0}\" does not exist.",
+                "MongoReader.ConnectionString.InvalidKey");
+        }
+
+        [Test]
+        public void GetConnectionString_ShouldThrowException_WhenNoConnectionStringSpecified()
+        {
+            var args = new NameValueCollection();
+
+            Assert.Throws<ApplicationException>(
+                () => MongoReaderPlugin.GetConnectionString(args),
+                "A MongoDB connection string must be specified.");
+        }
+    }
+}

--- a/Tests/ImageResizer.Plugins.MongoReader.Tests/ImageResizer.Plugins.MongoReader.Tests.csproj
+++ b/Tests/ImageResizer.Plugins.MongoReader.Tests/ImageResizer.Plugins.MongoReader.Tests.csproj
@@ -1,0 +1,114 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{36EDFBE6-51E0-4E37-939E-1851CD37E341}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ImageResizer.Plugins.MongoReader.Tests</RootNamespace>
+    <AssemblyName>ImageResizer.Plugins.MongoReader.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\binaries\debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\binaries\release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Gallio, Version=3.4.0.0, Culture=neutral, PublicKeyToken=eb9cfa67ee6ab36e, processorArchitecture=MSIL">
+      <HintPath>..\Packages\Gallio_MbUnit.3.4.14.0\lib\net40\Gallio.dll</HintPath>
+    </Reference>
+    <Reference Include="Gallio40, Version=3.4.0.0, Culture=neutral, PublicKeyToken=eb9cfa67ee6ab36e, processorArchitecture=MSIL">
+      <HintPath>..\Packages\Gallio_MbUnit.3.4.14.0\lib\net40\Gallio40.dll</HintPath>
+    </Reference>
+    <Reference Include="MbUnit, Version=3.4.0.0, Culture=neutral, PublicKeyToken=eb9cfa67ee6ab36e, processorArchitecture=MSIL">
+      <HintPath>..\Packages\Gallio_MbUnit.3.4.14.0\lib\net40\MbUnit.dll</HintPath>
+    </Reference>
+    <Reference Include="MbUnit40, Version=3.4.0.0, Culture=neutral, PublicKeyToken=eb9cfa67ee6ab36e, processorArchitecture=MSIL">
+      <HintPath>..\Packages\Gallio_MbUnit.3.4.14.0\lib\net40\MbUnit40.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise />
+  </Choose>
+  <ItemGroup>
+    <Compile Include="ConnectionStringTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\ImageResizer.csproj">
+      <Project>{FA5EF673-A6A4-498D-AA24-C025CC5267AF}</Project>
+      <Name>ImageResizer</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Plugins\MongoReader\ImageResizer.Plugins.MongoReader.csproj">
+      <Project>{C8D43F4E-103E-4CD7-B0D9-E97D9F708003}</Project>
+      <Name>ImageResizer.Plugins.MongoReader</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Tests/ImageResizer.Plugins.MongoReader.Tests/Properties/AssemblyInfo.cs
+++ b/Tests/ImageResizer.Plugins.MongoReader.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ImageResizer.Plugins.MongoReader.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ImageResizer.Plugins.MongoReader.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("e996c460-fa47-4c1e-bfb3-0315bb6fce8d")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Tests/ImageResizer.Plugins.MongoReader.Tests/packages.config
+++ b/Tests/ImageResizer.Plugins.MongoReader.Tests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Gallio_MbUnit" version="3.4.14.0" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
Provide extra configuration options so that a developer can re-use an existing connection string or app setting for their MongoDB URL