### PR TITLE
Update AzureReader2 to fix one small bug and improve performance.

### DIFF
--- a/Plugins/AzureReader2/AzureFile.cs
+++ b/Plugins/AzureReader2/AzureFile.cs
@@ -2,51 +2,50 @@
 using System;
 using System.IO;
 using System.Web.Hosting;
-using Microsoft.WindowsAzure;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
 
-namespace ImageResizer.Plugins.AzureReader2 {
+namespace ImageResizer.Plugins.AzureReader2
+{
 
-    public class AzureFile : VirtualFile, IVirtualFile {
+    /// <summary>
+    /// Represents a virtual file that reads the file from Microsoft Azure Blob Storage.
+    /// </summary>
+    public class AzureFile : VirtualFile, IVirtualFile
+    {
+        private readonly AzureVirtualPathProvider parent;
 
-        protected readonly AzureVirtualPathProvider parent;
-
-        public AzureFile(string blobName, AzureVirtualPathProvider parentProvider) : base(blobName) {
+        public AzureFile(string blobName, AzureVirtualPathProvider parentProvider)
+            : base(blobName)
+        {
             parent = parentProvider;
         }
         /// <summary>
-        /// Attempts to download the blob into a MemoryStream instance and return it. Throws a FileNotFoundException if the blob doesn't exist.
+        /// Attempts to download the blob into a MemoryStream instance and return it. Throws a FileNotFoundException if the blob or container doesn't exist.
+        /// Can also throw other exceptions from the StorageClient
         /// </summary>
-        /// <returns></returns>
-        public override System.IO.Stream Open() {
-            // Prefix already stripped from virtual path
-
+        public override Stream Open()
+        {
             MemoryStream ms = new MemoryStream(4096); // 4kb is a good starting point.
 
-            // Synchronously download
-            try {
-                // Get a reference to the blob
-                // mb: 12/8/2012 - the path needs to be a uri now, so combining blobclient baseuri with the virtualpath
+            try
+            {
                 Uri blobUri = new Uri(string.Format("{0}/{1}", parent.CloudBlobClient.BaseUri.OriginalString.TrimEnd('/', '\\'), VirtualPath));
                 ICloudBlob cloudBlob = parent.CloudBlobClient.GetBlobReferenceFromServer(blobUri);
 
                 cloudBlob.DownloadToStream(ms);
             }
-            catch (StorageException e) {
-                // mb: 12/8/2012 - not sure of the correctness of these following lines
-                // in other areas we just check e.RequestInformation.HttpStatusCode == 404 for a Not Found error
-                // don't know what the errorcodes that will be returned
-                if (e.RequestInformation.ExtendedErrorInformation.ErrorCode == "BlobNotFound") {
+            catch (StorageException e)
+            {
+                if (e.RequestInformation.ExtendedErrorInformation.ErrorCode == "BlobNotFound")
+                {
                     throw new FileNotFoundException("Azure blob file not found", e);
                 }
-                else if (e.RequestInformation.ExtendedErrorInformation.ErrorCode == "ContainerNotFound")
+                if (e.RequestInformation.ExtendedErrorInformation.ErrorCode == "ContainerNotFound")
                 {
                     throw new FileNotFoundException("Azure blob container not found", e);
                 }
-                else {
-                    throw;
-                }
+                throw;
             }
 
             ms.Seek(0, SeekOrigin.Begin); // Reset to beginning

--- a/Plugins/AzureReader2/AzureFile.cs
+++ b/Plugins/AzureReader2/AzureFile.cs
@@ -1,6 +1,7 @@
 ﻿/* Copyright (c) 2011 Wouter A. Alberts and Nathanael D. Jones. See license.txt for your rights. */
 using System;
 using System.IO;
+using System.Net;
 using System.Web.Hosting;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
@@ -37,13 +38,9 @@ namespace ImageResizer.Plugins.AzureReader2
             }
             catch (StorageException e)
             {
-                if (e.RequestInformation.ExtendedErrorInformation.ErrorCode == "BlobNotFound")
+                if (e.RequestInformation.HttpStatusCode == (int)HttpStatusCode.NotFound)
                 {
-                    throw new FileNotFoundException("Azure blob file not found", e);
-                }
-                if (e.RequestInformation.ExtendedErrorInformation.ErrorCode == "ContainerNotFound")
-                {
-                    throw new FileNotFoundException("Azure blob container not found", e);
+                    throw new FileNotFoundException("Azure error: " + e.RequestInformation.HttpStatusMessage, e);
                 }
                 throw;
             }

--- a/Plugins/AzureReader2/AzureReader.cs
+++ b/Plugins/AzureReader2/AzureReader.cs
@@ -8,47 +8,63 @@ using System.Collections.Generic;
 using ImageResizer.Configuration.Issues;
 using System.Security;
 using ImageResizer.Configuration.Xml;
+using Microsoft.WindowsAzure.Storage;
 
-namespace ImageResizer.Plugins.AzureReader2 {
-
-    public class AzureReader2Plugin : IPlugin, IIssueProvider, IMultiInstancePlugin, IRedactDiagnostics {
-
-        AzureVirtualPathProvider vpp = null;
-        string blobStorageConnection;
+namespace ImageResizer.Plugins.AzureReader2
+{
+    /// <summary>
+    /// A plugin that allows reading images directly from Microsoft Azure Blob Storage instead of local disk.
+    /// </summary>
+    public class AzureReader2Plugin : IPlugin, IIssueProvider, IMultiInstancePlugin, IRedactDiagnostics
+    {
+        const string defaultPrefix = "~/azure/";
+        AzureVirtualPathProvider vpp;
+        readonly string blobStorageConnection;
         string blobStorageEndpoint;
         string vPath;
-        bool lazyExistenceCheck = false;
+        readonly bool lazyExistenceCheck;
 
-        public AzureReader2Plugin(NameValueCollection args) {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="args">
+        /// The following settings can be passed in the NameValueCollection:
+        /// connectionSting: The connection string, or name of connection string to be used for Blob Storage. (REQUIRED)
+        /// blobStorageEndpoint: The http(s) base URL for the files. Can be used if you have a custom CNAME for your Storage Account or require HTTPS. Otherwise derived from connection string.
+        /// endpoint: alias for blobStorageEndpoint
+        /// prefix: can be used to override the default virtual path ("~/azure/")
+        /// vpp: register as Virtual Path Provider? Defaults to false.
+        /// </param>
+        public AzureReader2Plugin(NameValueCollection args)
+        {
+            FailedToRegisterVpp = false;
             blobStorageConnection = args["connectionstring"];
             blobStorageEndpoint = args["blobstorageendpoint"];
             if (string.IsNullOrEmpty(blobStorageEndpoint)) blobStorageEndpoint = args["endpoint"];
             vPath = args["prefix"];
-            lazyExistenceCheck = Utils.getBool(args, "lazyExistenceCheck", lazyExistenceCheck);
-            _registerAsVirtualPathProvider = Utils.getBool(args, "vpp", _registerAsVirtualPathProvider);
+            lazyExistenceCheck = ParseUtils.ParsePrimitive(args["lazyExistenceCheck"], lazyExistenceCheck);
+            RegisterAsVirtualPathProvider = ParseUtils.ParsePrimitive(args["vpp"], RegisterAsVirtualPathProvider);
         }
 
-
-        private bool _failedToRegisterVpp = false;
         /// <summary>
         /// True if the provider attempted to register itself as a VirtualPathProvider and failed due to limited security clearance.
         /// False if it did not attempt, or if it succeeded.
         /// </summary>
-        public bool FailedToRegisterVpp {
-            get { return _failedToRegisterVpp; }
-        }
+        public bool FailedToRegisterVpp { get; private set; }
 
-        private bool _registerAsVirtualPathProvider = true;
         /// <summary>
         /// True to register the plugin as  VPP, false to register it as a VIP. VIPs are only visible to the ImageResizer pipeline - i.e, only processed images are visible. 
         /// </summary>
-        public bool RegisterAsVirtualPathProvider {
-            get { return _registerAsVirtualPathProvider; }
-            set { _registerAsVirtualPathProvider = value; }
-        }
+        public bool RegisterAsVirtualPathProvider { get; set; }
 
-
-        public IPlugin Install(Configuration.Config c) {
+        /// <summary>
+        /// Installs the AzureReader2 plugin into the ImageResizer configuration provided
+        /// </summary>
+        /// <param name="c">The configuration to install the plugin into</param>
+        /// <returns></returns>
+        /// <exception cref="InvalidOperationException">Throws an exception if the configuration is invalid</exception>
+        public IPlugin Install(Configuration.Config c)
+        {
             if (vpp != null)
                 throw new InvalidOperationException("This plugin can only be installed once, and cannot be uninstalled and reinstalled.");
 
@@ -56,37 +72,60 @@ namespace ImageResizer.Plugins.AzureReader2 {
                 throw new InvalidOperationException("This plugin needs a connection string for the Azure blob storage.");
 
             if (string.IsNullOrEmpty(blobStorageEndpoint))
-                throw new InvalidOperationException("This plugin needs a blob end point; the default will be [http|https]://myaccount.blob.core.windows.net.");
+            {
+                CloudStorageAccount cloudStorageAccount;
+                if (CloudStorageAccount.TryParse(blobStorageConnection, out cloudStorageAccount))
+                {
+                    blobStorageEndpoint = cloudStorageAccount.BlobEndpoint.ToString();
+                }
+                else
+                {
+                    throw new InvalidOperationException("This plugin needs a correct blob storage connection to be able to automatically find the storage endpoint.");
+                }
+            }
 
             if (!blobStorageEndpoint.EndsWith("/"))
                 blobStorageEndpoint += "/";
 
             if (string.IsNullOrEmpty(vPath))
-                vPath = "~/azure/";
+                vPath = defaultPrefix;
 
-            vpp = new AzureVirtualPathProvider(blobStorageConnection);
-            vpp.VirtualFilesystemPrefix = vPath;
-            vpp.LazyExistenceCheck = lazyExistenceCheck;
+            vpp = new AzureVirtualPathProvider(blobStorageConnection)
+            {
+                VirtualFilesystemPrefix = vPath,
+                LazyExistenceCheck = lazyExistenceCheck
+            };
 
-            if (RegisterAsVirtualPathProvider) {
-                try {
+            if (RegisterAsVirtualPathProvider)
+            {
+                try
+                {
                     HostingEnvironment.RegisterVirtualPathProvider(vpp);
-                } catch (SecurityException) {
-                    this._failedToRegisterVpp = true;
+                }
+                catch (SecurityException)
+                {
+                    FailedToRegisterVpp = true;
                     c.Plugins.VirtualProviderPlugins.Add(vpp); //Fall back to VIP instead.
                 }
             }
 
             // Register rewrite
             c.Pipeline.PostRewrite += Pipeline_PostRewrite;
-
             c.Plugins.add_plugin(this);
-
             return this;
         }
 
-        public Configuration.Xml.Node RedactFrom(Node resizer) {
-            foreach (Node n in resizer.queryUncached("plugins.add")) {
+        /// <summary>
+        /// Internal use only. Removes connection string from config before displaying.
+        /// </summary>
+        /// <param name="resizer"></param>
+        /// <returns></returns>
+        public Node RedactFrom(Node resizer)
+        {
+            var nodes = resizer.queryUncached("plugins.add");
+            if (nodes == null) return resizer;
+            foreach (Node n in nodes)
+            {
                 if (n.Attrs["connectionString"] != null) n.Attrs.Set("connectionString", "[redacted]");
             }
             return resizer;
@@ -94,16 +133,18 @@ namespace ImageResizer.Plugins.AzureReader2 {
 
         /// <summary>
         /// In case there is no querystring attached to the file (thus no operations on the fly) we can
-        /// redirect directly to the blob. This let us take advantage of the CDN (if configured).
+        /// redirect directly to the blob. This let us offload traffic to blob storage.
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="context"></param>
         /// <param name="e"></param>
-        void Pipeline_PostRewrite(IHttpModule sender, HttpContext context, Configuration.IUrlEventArgs e) {
+        void Pipeline_PostRewrite(IHttpModule sender, HttpContext context, Configuration.IUrlEventArgs e)
+        {
             string prefix = vpp.VirtualFilesystemPrefix;
 
             // Check if prefix is within virtual file system and if there is no querystring
-            if (e.VirtualPath.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) && e.QueryString.Count == 0) {
+            if (e.VirtualPath.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) && e.QueryString.Count == 0)
+            {
 
                 // Strip prefix from virtual path; keep container and blob
                 string relativeBlobURL = e.VirtualPath.Substring(prefix.Length).TrimStart('/', '\\');
@@ -113,9 +154,16 @@ namespace ImageResizer.Plugins.AzureReader2 {
             }
         }
 
-        public bool Uninstall(Configuration.Config c) {
-            //We can uninstall if it wasn't installed as a VPP
-            if (!RegisterAsVirtualPathProvider || FailedToRegisterVpp) {
+        /// <summary>
+        /// Uninstall the plugin from the provided configuration. Only possible if not registered as a Virtual Path Provider.
+        /// </summary>
+        /// <param name="c">The configuration to uninstall the plugin from</param>
+        /// <returns></returns>
+        public bool Uninstall(Configuration.Config c)
+        {
+            // We can uninstall if it wasn't installed as a VPP
+            if (!RegisterAsVirtualPathProvider || FailedToRegisterVpp)
+            {
                 c.Plugins.VirtualProviderPlugins.Remove(vpp);
                 c.Pipeline.PostRewrite -= Pipeline_PostRewrite;
                 c.Plugins.remove_plugin(this);
@@ -128,17 +176,15 @@ namespace ImageResizer.Plugins.AzureReader2 {
         /// Provides the diagnostics system with a list of configuration issues
         /// </summary>
         /// <returns></returns>
-        public IEnumerable<IIssue> GetIssues() {
+        public IEnumerable<IIssue> GetIssues()
+        {
             List<IIssue> issues = new List<IIssue>();
 
             if (FailedToRegisterVpp)
-                issues.Add(new Issue("AzureReader", "Failed to register as VirtualPathProvider.",
+                issues.Add(new Issue("AzureReader2", "Failed to register as VirtualPathProvider.",
                     "Only the image resizer will be able to access files located in Azure Blob Storage - other systems will not be able to.", IssueSeverity.Error));
-
 
             return issues;
         }
-
-
     }
 }

--- a/Plugins/AzureReader2/AzureVirtualPathProvider.cs
+++ b/Plugins/AzureReader2/AzureVirtualPathProvider.cs
@@ -1,55 +1,49 @@
 ﻿/* Copyright (c) 2011 Wouter A. Alberts and Nathanael D. Jones. See license.txt for your rights. */
 using System;
-using System.Security.Permissions;
-using System.Web;
+using System.Collections.Specialized;
 using System.Web.Hosting;
 using Microsoft.WindowsAzure;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
 using ImageResizer.Util;
 
-namespace ImageResizer.Plugins.AzureReader2 {
-
-     public class AzureVirtualPathProvider : VirtualPathProvider, IVirtualImageProvider {
+namespace ImageResizer.Plugins.AzureReader2
+{
+    /// <summary>
+    /// A virtual path provider for files stored on Microsoft Azure Blob Storage.
+    /// </summary>
+    public class AzureVirtualPathProvider : VirtualPathProvider, IVirtualImageProvider
+    {
 
         private string _virtualFilesystemPrefix = PathUtils.ResolveAppRelative("~/azure/");
-        private CloudBlobClient _cloudBlobClient = null;
-
         /// <summary>
         /// Requests starting with this path will be handled by this virtual path provider.
         /// Can be in app-relative form: "~/azure/". Will be translated to domain-relative form.
         /// </summary>
-        public string VirtualFilesystemPrefix {
-            get {
+        public string VirtualFilesystemPrefix
+        {
+            get
+            {
                 return _virtualFilesystemPrefix;
             }
-            set {
+            set
+            {
                 if (!value.EndsWith("/")) value += "/";
-                _virtualFilesystemPrefix = value != null ? PathUtils.ResolveAppRelativeAssumeAppRelative(value) : value;
-                
+                _virtualFilesystemPrefix = PathUtils.ResolveAppRelativeAssumeAppRelative(value);
             }
         }
 
-        private bool _lazyExistenceCheck = false;
         /// <summary>
-        /// If true, 
+        /// If true, do not check if blob exists before trying to read it. This is faster and slightly cheaper 
+        /// (saves one storage transaction), but adds the risk of redirecting to a blob that will return a 404
+        /// from blob storage to the end user.
         /// </summary>
-        public bool LazyExistenceCheck {
-            get { return _lazyExistenceCheck; }
-            set { _lazyExistenceCheck = value; }
-        }
+        public bool LazyExistenceCheck { get; set; }
 
+        internal CloudBlobClient CloudBlobClient { get; set; }
 
-        public CloudBlobClient CloudBlobClient {
-            get {
-                return _cloudBlobClient;
-            }
-            set {
-                _cloudBlobClient = value;
-            }
-        }
-        
-        public AzureVirtualPathProvider(string blobStorageConnection) {
+        internal AzureVirtualPathProvider(string blobStorageConnection)
+        {
             // Setup the connection to Windows Azure Storage
 
             // The 1.x Azure SDK offers a CloudStorageAccount.FromConfigurationSetting()
@@ -78,30 +72,20 @@ namespace ImageResizer.Plugins.AzureReader2 {
         /// <returns>
         /// True if the virtual path is within the virtual file sytem; otherwise, false.
         /// </returns>
-        public bool IsPathVirtual(string virtualPath){
+        public bool IsPathVirtual(string virtualPath)
+        {
             return (virtualPath.StartsWith(VirtualFilesystemPrefix, StringComparison.OrdinalIgnoreCase));
         }
+
         /// <summary>
         /// Internal usage only
         /// </summary>
         /// <param name="virtualPath"></param>
         /// <returns></returns>
-        public override bool FileExists(string virtualPath) {
-            if (FileExists(virtualPath, null))
-                return true;
-            else {
-                return Previous.FileExists(virtualPath);
-            }
-        }
-
-        /// <summary>
-        /// For internal use only
-        /// </summary>
-        /// <param name="virtualPath"></param>
-        /// <returns></returns>
-        public override VirtualFile GetFile(string virtualPath) {
-            VirtualFile vf = (VirtualFile)GetFile(virtualPath, null);
-            return (vf == null) ? Previous.GetFile(virtualPath) : vf;
+        public override bool FileExists(string virtualPath)
+        {
+            if (FileExists(virtualPath, null)) return true;
+            return Previous.FileExists(virtualPath);
         }
 
         /// <summary>
@@ -110,56 +94,66 @@ namespace ImageResizer.Plugins.AzureReader2 {
         /// <param name="virtualPath"></param>
         /// <param name="queryString"></param>
         /// <returns></returns>
-        public bool FileExists(string virtualPath, System.Collections.Specialized.NameValueCollection queryString) {
-            if (IsPathVirtual(virtualPath)) {
-                if (LazyExistenceCheck) return true;
+        public bool FileExists(string virtualPath, NameValueCollection queryString)
+        {
+            if (!IsPathVirtual(virtualPath)) return false;
+            if (LazyExistenceCheck) return true;
 
-                try {
-                    // Strip prefix from virtual path; keep container and blob
-                    // mb:12/8/2012 - need to prepend the blob client base uri to the url
-                    string relativeBlobURL = string.Format("{0}/{1}", CloudBlobClient.BaseUri.OriginalString.TrimEnd('/', '\\'), virtualPath.Substring(VirtualFilesystemPrefix.Length).Trim('/', '\\'));
+            try
+            {
+                // Strip prefix from virtual path; keep container and blob
+                string relativeBlobURL = string.Format("{0}/{1}", CloudBlobClient.BaseUri.OriginalString.TrimEnd('/', '\\'), virtualPath.Substring(VirtualFilesystemPrefix.Length).Trim('/', '\\'));
 
-                    // Get a reference to the blob
-                    // mb:12/8/2012 - this call now must be a uri
-                    ICloudBlob cloudBlob = CloudBlobClient.GetBlobReferenceFromServer(new Uri(relativeBlobURL));
-
-                    cloudBlob.FetchAttributes();
-                    return true;
-                } catch (StorageException e) {
-                    if (e.RequestInformation.HttpStatusCode == 404) {
-                        return false;
-                    } else {
-                        throw;
-                    }
-                }
+                // Get a reference to the blob, this will throw if blob does not exist
+                CloudBlobClient.GetBlobReferenceFromServer(new Uri(relativeBlobURL));
+                return true;
             }
-            return false;
+            catch (StorageException e)
+            {
+                if (e.RequestInformation.HttpStatusCode == 404)
+                {
+                    return false;
+                }
+                throw;
+            }
         }
 
-        public IVirtualFile GetFile(string virtualPath, System.Collections.Specialized.NameValueCollection queryString) {
-            if (IsPathVirtual(virtualPath)) {
-                // Strip prefix from virtual path; keep container and blob
-                string relativeBlobURL = virtualPath.Substring(VirtualFilesystemPrefix.Length).Trim('/', '\\');
+        /// <summary>
+        /// For internal use only
+        /// </summary>
+        /// <param name="virtualPath"></param>
+        /// <returns></returns>
+        public override VirtualFile GetFile(string virtualPath)
+        {
+            VirtualFile vf = (VirtualFile)GetFile(virtualPath, null);
+            return vf ?? Previous.GetFile(virtualPath);
+        }
 
+        /// <summary>
+        /// For internal use only
+        /// </summary>
+        /// <param name="virtualPath"></param>
+        /// <param name="queryString"></param>
+        /// <returns></returns>
+        public IVirtualFile GetFile(string virtualPath, NameValueCollection queryString)
+        {
+            if (!IsPathVirtual(virtualPath)) return null;
 
-                try {
-                    if (!LazyExistenceCheck) {
-                        // Get a reference to the blob
-                        // mb: 12/8/2012 - creating uri here to keep the above relativeBlobURL as is to create & return an AzureFile
-                        Uri relativeBlobUri = new Uri(string.Format("{0}/{1}", CloudBlobClient.BaseUri.OriginalString.TrimEnd('/', '\\'), relativeBlobURL));
-                        ICloudBlob cloudBlob = CloudBlobClient.GetBlobReferenceFromServer(relativeBlobUri);
-                        cloudBlob.FetchAttributes();
-                    }
-                    return new AzureFile(relativeBlobURL, this);
-                } catch (StorageException e) {
-                    if (e.RequestInformation.HttpStatusCode == 404) {
-                        return null;
-                    } else {
-                        throw;
-                    }
-                }
+            // Strip prefix from virtual path; keep container and blob
+            string relativeBlobURL = virtualPath.Substring(VirtualFilesystemPrefix.Length).Trim('/', '\\');
+
+            try
+            {
+                return new AzureFile(relativeBlobURL, this);
             }
-            return null;
+            catch (StorageException e)
+            {
+                if (e.RequestInformation.HttpStatusCode == 404)
+                {
+                    return null;
+                }
+                throw;
+            }
         }
     }
 }


### PR DESCRIPTION
* Minimize number of calls to Microsoft Azure Blob Storage for existence
checks.
* Avoid ArgumentNullException in RedactFrom() when plugin is added from code, not config.
* Makes as many variables private/internal as possible.
* Automatically derive storage endpoint from connection string if none
is provided.
* Make properties auto properties where appropriate.
* More comments.

I hope that I have kept your coding style well enough. I am used to different (ReSharper) style :)