### PR TITLE
Fixed issue in TinyCache - calculating the Average will fail if recent_reads is empty

### DIFF
--- a/Plugins/TinyCache/CacheEntry.cs
+++ b/Plugins/TinyCache/CacheEntry.cs
@@ -77,7 +77,7 @@ namespace ImageResizer.Plugins.TinyCache {
 
             //How long has it been since the average of the last 8 reads?
             //Divide by last 30 minutes
-            float recent_usage = (float)Math.Min(0, 1 - Math.Max(30, recent_reads.Average(d => now.Subtract(d).TotalMinutes)) / 30.0);
+            float recent_usage = recent_reads.Count == 0 ? (float)Math.Min(0, 1 - Math.Max(30, recent_reads.Average(d => now.Subtract(d).TotalMinutes)) / 30.0);
 
             float recent_usage_weight = 1 - (float)(Math.Max(30, now.Subtract(loaded).TotalMinutes) / 30);
 


### PR DESCRIPTION
If `recent_reads` does not contain any element, `recent_reads.Average` fails. This pull request will solve this issue with a condition (setting 0 for `recent_usage`).
I'm not sure if this has other side effects, but I have tested it and it seems to work fine.
