### PR TITLE
Added the ability to have certain query string parameters excluded from the cache key

### DIFF
--- a/Core/Configuration/IPipelineConfig.cs
+++ b/Core/Configuration/IPipelineConfig.cs
@@ -162,5 +162,7 @@ namespace ImageResizer.Configuration {
         NameValueCollection ModifiedQueryString { get; set; }
 
         bool IsAppDomainUnrestricted();
+
+        string DropQuerystringKeys { get; set; }
     }
 }

--- a/Core/Configuration/PipelineConfig.cs
+++ b/Core/Configuration/PipelineConfig.cs
@@ -223,7 +223,21 @@ namespace ImageResizer.Configuration {
             get {
                 if (HttpContext.Current == null) return null;
                 if (HttpContext.Current.Items[ModifiedQueryStringKey] == null)
-                    HttpContext.Current.Items[ModifiedQueryStringKey] = new NameValueCollection(HttpContext.Current.Request.QueryString);
+                {
+                    NameValueCollection qs = new NameValueCollection(HttpContext.Current.Request.QueryString);
+
+                    //see if we have query string parameters that we want to have ignored, e.g. cachebusters
+                    string dropQuerystringKeys = this.DropQuerystringKeys;
+                    if (!string.IsNullOrEmpty(dropQuerystringKeys))
+                    {
+                        foreach (string dropQuerystringKey in dropQuerystringKeys.Split(','))
+                        {
+                            qs.Remove(dropQuerystringKey);
+                        }
+                    }
+
+                    HttpContext.Current.Items[ModifiedQueryStringKey] = qs;
+                }
 
                 return (NameValueCollection)HttpContext.Current.Items[ModifiedQueryStringKey];
             }
@@ -597,6 +611,27 @@ namespace ImageResizer.Configuration {
             }
 
             return defaultCache;
+        }
+
+        private string _dropQuerystringKeys = null;
+
+        /// <summary>
+        /// If specified, DropQuerystringKeys will cause certain query string parameters to be excluded from processing.
+        /// </summary>
+        public string DropQuerystringKeys
+        {
+            get
+            {
+                if (_dropQuerystringKeys == null)
+                {
+                    _dropQuerystringKeys = c.get("pipeline.dropQuerystringKeys", "");
+                }
+                return _dropQuerystringKeys;
+            }
+            set
+            {
+                _dropQuerystringKeys = value;
+            }
         }
     }
 }


### PR DESCRIPTION
sometimes one might want to exclude certain query string parameters from
the cache key, e.g. when using a qs parameter as a cache buster for a
CDN, etc.

added the ability to do this via the configuration:

`<pipeline dropQuerystringKeys="" />`

the parameternames attribute accepts a comma-delimited list of parameter
names that will be ignored by internal processing (and thus also from
the cache key)

This replaces pull request #113 
