### PR TITLE
prevented conversion of grayscale image to grayscale during face recognition which would otherwise result in an exception

### DIFF
--- a/Plugins/Faces/FeatureDetectionBase.cs
+++ b/Plugins/Faces/FeatureDetectionBase.cs
@@ -93,10 +93,7 @@ namespace ImageResizer.Plugins.Faces {
             List<T> features;
             //Type Intializer Exception occurs if you reuse an appdomain. Always restart the server.
             using (IplImage orig = OpenCvSharp.BitmapConverter.ToIplImage(b))
-            using (IplImage gray = new IplImage(orig.Size, BitDepth.U8, 1)) {
-
-                //Make grayscale version
-                Cv.CvtColor(orig, gray, ColorConversion.BgrToGray);
+            using (IplImage gray = GetOriginalImageInGrayScale(orig)) {
 
                 int w = orig.Width; int h = orig.Height;
                 double ratio = (double)w / (double)h;
@@ -146,6 +143,20 @@ namespace ImageResizer.Plugins.Faces {
                     Cascades[s] = null;
                 }
             }
+        }
+
+        private static IplImage GetOriginalImageInGrayScale(IplImage originalImage)
+        {
+            if (originalImage.NChannels == 1)
+            {
+                // the image is already in grayscale, so no need to convert it
+                return originalImage;
+            }
+
+            //Make grayscale version
+            IplImage grayScaleImage = new IplImage(originalImage.Size, BitDepth.U8, 1);
+            Cv.CvtColor(originalImage, grayScaleImage, ColorConversion.BgrToGray);
+            return grayScaleImage;
         }
     }
 }


### PR DESCRIPTION
The Face recognition plugin crashes when an image is provided that is already in gray scale, put otherwise, it fails when the provided image has only one color channel.
This fix will check for the number of channels and if this is 1, then the original image will be returned as the gray scale version of itself instead of creating a new one which would fail otherwise with the following exception:

``` c#
[OpenCVException: scn == 3 || scn == 4]
   OpenCvSharp.CvInvoke.&lt;.cctor&gt;b__0(CvStatus status, String func_name, String err_msg, String file_name, Int32 line, IntPtr userdata) +134
   OpenCvSharp.CvInvoke.cvCvtColor(IntPtr src, IntPtr dst, ColorConversion code) +0
   ImageResizer.Plugins.Faces.FeatureDetectionBase`1.DetectFeatures(Bitmap b) +260
   ImageResizer.Plugins.Faces.FacesPlugin.PostPrepareSourceBitmap(ImageState s) +655
   ImageResizer.Resizing.AbstractImageProcessor.PostPrepareSourceBitmap(ImageState s) +99
   ImageResizer.ImageBuilder.Process(ImageState s) +60
   ImageResizer.ImageBuilder.buildToBitmap(Bitmap source, ResizeSettings settings, Boolean transparencySupported) +276
   ImageResizer.ImageBuilder.buildToStream(Bitmap source, Stream dest, ResizeSettings settings) +149
   ImageResizer.ImageBuilder.BuildJob(ImageJob job) +1353
   ImageResizer.ImageBuilder.Build(ImageJob job) +268
   ImageResizer.ImageBuilder.Build(Object source, Object dest, ResizeSettings settings, Boolean disposeSource, Boolean addFileExtension) +124
   ImageResizer.ImageBuilder.Build(Object source, Object dest, ResizeSettings settings, Boolean disposeSource) +36
   ImageResizer.ImageBuilder.Build(Object source, Object dest, ResizeSettings settings) +23
   ImageResizer.&lt;&gt;c__DisplayClass3.&lt;HandleRequest&gt;b__2(Stream stream) +287
   ImageResizer.Plugins.DiskCache.&lt;&gt;c__DisplayClasse.&lt;TryWriteFile&gt;b__d() +596
   ImageResizer.Plugins.DiskCache.LockProvider.TryExecute(String key, Int32 timeoutMs, LockCallback success) +424
   ImageResizer.Plugins.DiskCache.CustomDiskCache.TryWriteFile(CacheResult result, String physicalPath, String relativePath, ResizeImageDelegate writeCallback, DateTime sourceModifiedUtc, Int32 timeoutMs, Boolean recheckFS) +517
   ImageResizer.Plugins.DiskCache.CustomDiskCache.GetCachedFile(String keyBasis, String extension, ResizeImageDelegate writeCallback, DateTime sourceModifiedUtc, Int32 timeoutMs, Boolean asynchronous) +819
   ImageResizer.Plugins.DiskCache.DiskCache.Process(IResponseArgs e) +209
   ImageResizer.Plugins.DiskCache.DiskCache.Process(HttpContext context, IResponseArgs e) +47
   ImageResizer.InterceptModule.HandleRequest(HttpContext context, String virtualPath, NameValueCollection queryString, IVirtualFile vf) +1687
   ImageResizer.InterceptModule.CheckRequest_PostAuthorizeRequest(Object sender, EventArgs e) +1163
   System.Web.SyncEventExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute() +80
   System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean&amp; completedSynchronously) +165
```

where the `scn == 3 || scn == 4` part indicates that the source image must have 3 or 4 channels
