### PR TITLE
Reduce GC Pressure by eliminating new char[] calls.

### DIFF
--- a/Core.Mvc/ImageRequestAction.cs
+++ b/Core.Mvc/ImageRequestAction.cs
@@ -92,7 +92,7 @@ using ImageResizer.ExtensionMethods;
 //                //Who's the user
 //                IPrincipal user = app.Context.User as IPrincipal;
 //                // no user (must be anonymous...).. Or authentication doesn't work for this suffix. Whatever, just avoid a nullref in the UrlAuthorizationModule
-//                if (user == null)  user = new GenericPrincipal(new GenericIdentity(string.Empty, string.Empty), new string[0]);
+//                if (user == null)  user = new GenericPrincipal(new GenericIdentity(string.Empty, string.Empty), ParseUtils.EmptyStringArray);
 //                //Do we have permission to call UrlAuthorizationModule.CheckUrlAccessForPrincipal?
 //                bool canCheckUrl = System.Security.SecurityManager.IsGranted(new System.Security.Permissions.SecurityPermission(System.Security.Permissions.PermissionState.Unrestricted));
 //                //Run the rewritten path past the auth system again, using the result as the default "AllowAccess" value
@@ -191,7 +191,7 @@ using ImageResizer.ExtensionMethods;
 //            //Determine the file extenson for the caching system to use if we aren't processing the image
 //            //Use the exsiting one if is an image extension. If not, use "unknown". 
 //            // We don't want to suggest writing .exe or .aspx files to the cache! 
-//            string fallbackExtension = PathUtils.GetFullExtension(virtualPath).TrimStart('.'); 
+//            string fallbackExtension = PathUtils.GetFullExtension(virtualPath).TrimStart(ParseUtils.Period); 
 //            if (!conf.IsAcceptedImageType(virtualPath)) fallbackExtension = "unknown";
 
 //            //Determine the mime-type if we aren't processing the image.

--- a/Core/Configuration/Issues/ConfigChecker.cs
+++ b/Core/Configuration/Issues/ConfigChecker.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Security.Principal;
 using System.Web.Security;
 using System.Web.Hosting;
+using ImageResizer.Util;
 
 namespace ImageResizer.Configuration.Issues {
     public class ConfigChecker:IIssueProvider {
@@ -31,8 +32,8 @@ namespace ImageResizer.Configuration.Issues {
 
             if (canCheckUrls) {
                 try {
-                    IPrincipal user = new GenericPrincipal(new GenericIdentity(string.Empty, string.Empty), new string[0]);
-                    UrlAuthorizationModule.CheckUrlAccessForPrincipal(HostingEnvironment.ApplicationVirtualPath.TrimEnd('/') + '/', user, "GET");
+                    IPrincipal user = new GenericPrincipal(new GenericIdentity(string.Empty, string.Empty), ParseUtils.EmptyStringArray);
+                    UrlAuthorizationModule.CheckUrlAccessForPrincipal(HostingEnvironment.ApplicationVirtualPath.TrimEnd(ParseUtils.ForwardSlash) + '/', user, "GET");
                 } catch (NotImplementedException) {
                     issues.Add(new Issue("UrlAuthorizationModule.CheckUrlAccessForPrincipal is not supported on this runtime (are you running Mono?)",
                          "It may be possible for users to bypass UrlAuthorization rules you have defined for your website, and access images that would otherwise be protected. If you do not use UrlAuthorization rules, this should not be a concern. " +
@@ -63,7 +64,7 @@ namespace ImageResizer.Configuration.Issues {
                     if (((AssemblyInformationalVersionAttribute)attrs[0]).InformationalVersion.IndexOf("hotfix",StringComparison.OrdinalIgnoreCase) > -1)
                         assembliesRunningHotfix += assemblyName.Name + ", ";
             }
-            assembliesRunningHotfix = assembliesRunningHotfix.TrimEnd(',',' ');
+            assembliesRunningHotfix = assembliesRunningHotfix.TrimEnd(ParseUtils.SpaceOrComma);
 
             if (!string.IsNullOrEmpty(assembliesRunningHotfix))
                 issues.Add(new Issue("You are running a hotfix version of the ImageResizer.",

--- a/Core/Configuration/PipelineConfig.cs
+++ b/Core/Configuration/PipelineConfig.cs
@@ -14,6 +14,7 @@ using ImageResizer.Collections;
 using System.Web;
 using System.Security.Permissions;
 using System.Runtime.InteropServices;
+using ImageResizer.Util;
 
 namespace ImageResizer.Configuration {
     public class PipelineConfig : IPipelineConfig, ICacheProvider, ISettingsModifier{
@@ -62,7 +63,7 @@ namespace ImageResizer.Configuration {
                 vals = p.GetSupportedFileExtensions();
                 if (vals != null)
                     foreach (string e in vals)
-                        exts[e.TrimStart('.')] = true;
+                        exts[e.TrimStart(ParseUtils.Period)] = true;
             }
 
 
@@ -72,7 +73,7 @@ namespace ImageResizer.Configuration {
                 vals = b.GetSupportedFileExtensions();
                 if (vals != null)
                     foreach (string e in vals)
-                        exts[e.TrimStart('.')] = true;
+                        exts[e.TrimStart(ParseUtils.Period)] = true;
 
                 vals = b.GetSupportedQuerystringKeys();
                 if (vals != null)
@@ -117,7 +118,7 @@ namespace ImageResizer.Configuration {
 
         protected string getExtension(string path) {
             //Trim off the extension
-            int lastDot = path.LastIndexOfAny(new char[] { '.', '/', ' ', '\\', '?', '&', ':' });
+            int lastDot = path.LastIndexOfAny(ParseUtils.PathParts);
             if (lastDot > -1 && path[lastDot] == '.') return path.Substring(lastDot + 1);
             else return null;
         }
@@ -158,7 +159,7 @@ namespace ImageResizer.Configuration {
             get {
                 IList<string> temp = _fakeExtensions;
                 if (temp != null) return temp;
-                else temp = new List<string>(c.get("pipeline.fakeExtensions",".ashx").Split(new char[]{','}, StringSplitOptions.RemoveEmptyEntries));
+                else temp = new List<string>(c.get("pipeline.fakeExtensions",".ashx").Split(ParseUtils.Comma, StringSplitOptions.RemoveEmptyEntries));
                 for (int i = 0; i < temp.Count; i++) {
                     if (!temp[i].StartsWith(".", StringComparison.OrdinalIgnoreCase)) temp[i] = "." + temp[i];
                 }
@@ -174,7 +175,7 @@ namespace ImageResizer.Configuration {
         public string TrimFakeExtensions(string path) {
             foreach (string s in FakeExtensions) {
                 if (path.EndsWith(s, StringComparison.OrdinalIgnoreCase)) {
-                    path = path.Substring(0, path.Length - s.Length).TrimEnd('.');
+                    path = path.Substring(0, path.Length - s.Length).TrimEnd(ParseUtils.Period);
                     break;
                 }
             }

--- a/Core/Configuration/PluginConfig.cs
+++ b/Core/Configuration/PluginConfig.cs
@@ -16,6 +16,7 @@ using ImageResizer.Collections;
 using ImageResizer.Configuration.Logging;
 using System.Web.Compilation;
 using ImageResizer.Configuration.Plugins;
+using ImageResizer.Util;
 
 namespace ImageResizer.Configuration {
     /// <summary>
@@ -397,19 +398,21 @@ namespace ImageResizer.Configuration {
             //ImageResizer.Plugins.Basic.DefaultEncoder
             if (hasDot) alternateNames.Add(name);
             //DefaultEncoder, NoCache, etc.
-            alternateNames.Add("ImageResizer.Plugins.Basic." + name.TrimStart('.'));
-            //Apr4-2012 - Deleted, never used: alternateNames.Add("ImageResizer.Plugins.Pro." + name.TrimStart('.'));
+            alternateNames.Add("ImageResizer.Plugins.Basic." + name.TrimStart(ParseUtils.Period));
+            //Apr4-2012 - Deleted, never used: alternateNames.Add("ImageResizer.Plugins.Pro." + name.TrimStart(ParseUtils.Period));
             //AnimatedGifs
-            if (!hasDot) alternateNames.Add("ImageResizer.Plugins." + name.Trim('.') + "." + name.Trim('.') + "Plugin");
+            if (!hasDot)
+                alternateNames.Add("ImageResizer.Plugins." + name.Trim(ParseUtils.Period) + "." + name.Trim(ParseUtils.Period) + "Plugin");
             //AnimatedGifsPlugin
             if (!hasDot && name.EndsWith("Plugin"))
-                alternateNames.Add("ImageResizer.Plugins." + name.Substring(0, name.Length - 6).Trim('.') + "." + name.Trim('.'));
+                alternateNames.Add("ImageResizer.Plugins." + name.Substring(0, name.Length - 6).Trim(ParseUtils.Period) + "." + name.Trim(ParseUtils.Period));
             //Apr4-2012 - Deleted, never used: //Basic.DefaultEncoder
-            //Apr4-2012 - Deleted, never used: alternateNames.Add("ImageResizer.Plugins." + name.TrimStart('.'));
+            //Apr4-2012 - Deleted, never used: alternateNames.Add("ImageResizer.Plugins." + name.TrimStart(ParseUtils.Period));
             //For the deprecated convention of naming the plugin namespace and class the same.
-            if (!hasDot) alternateNames.Add("ImageResizer.Plugins." + name.Trim('.') + "." + name.Trim('.'));
+            if (!hasDot)
+                alternateNames.Add("ImageResizer.Plugins." + name.Trim(ParseUtils.Period) + "." + name.Trim(ParseUtils.Period));
             //Apr4-2012 - Deleted, never used: //Plugins.Basic.DefaultEncoder
-            //Apr4-2012 - Deleted, never used: alternateNames.Add("ImageResizer." + name.TrimStart('.'));
+            //Apr4-2012 - Deleted, never used: alternateNames.Add("ImageResizer." + name.TrimStart(ParseUtils.Period));
             //PluginWithNoNamespace
             if (!hasDot) alternateNames.Add(name);
 

--- a/Core/Configuration/Xml/Node.cs
+++ b/Core/Configuration/Xml/Node.cs
@@ -6,6 +6,7 @@ using System.Collections.Specialized;
 using System.Xml;
 using ImageResizer.Configuration.Issues;
 using System.Collections.ObjectModel;
+using ImageResizer.Util;
 
 namespace ImageResizer.Configuration.Xml {
     /// <summary>
@@ -122,7 +123,7 @@ namespace ImageResizer.Configuration.Xml {
         }
 
         protected KeyValuePair<string, string> parseAttributeName(string selector) {
-            selector = selector.Trim('.');
+            selector = selector.Trim(ParseUtils.Period);
             int lastDot = selector.LastIndexOf('.');
             if (lastDot < 0) throw new ArgumentException("Selector must include an attribute name, like element.attrname. Was given '" + selector + "'");
             string nodeSelector = selector.Substring(0, lastDot);
@@ -209,7 +210,7 @@ namespace ImageResizer.Configuration.Xml {
         public ICollection<Node> queryUncached(string selector) {
             if (children == null || children.Count == 0) return null;
 
-            selector = selector.Trim('.'); //Trim leading and trailing dots
+            selector = selector.Trim(ParseUtils.Period); //Trim leading and trailing dots
             
             int nextDot = selector.IndexOf('.');
             //Get the first item

--- a/Core/Configuration/Xml/Selector.cs
+++ b/Core/Configuration/Xml/Selector.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using ImageResizer.Util;
 
 namespace ImageResizer.Configuration.Xml {
     /// <summary>
@@ -11,8 +12,9 @@ namespace ImageResizer.Configuration.Xml {
         public Selector(List<string> items) {
             this.AddRange(items);
         }
-        public Selector(string selector):base(selector.Trim('.').Split(new char[]{'.'}, StringSplitOptions.RemoveEmptyEntries)) {
-            
+
+        public Selector(string selector) : base(selector.Trim(ParseUtils.Period).Split(ParseUtils.Period, StringSplitOptions.RemoveEmptyEntries))
+        {
         }
 
         public string Last {

--- a/Core/ExtensionMethods/Enum.cs
+++ b/Core/ExtensionMethods/Enum.cs
@@ -4,6 +4,7 @@ using System.Text;
 using ImageResizer.Collections;
 using System.Reflection;
 using System.Globalization;
+using ImageResizer.Util;
 
 namespace ImageResizer.ExtensionMethods {
 
@@ -126,7 +127,7 @@ namespace ImageResizer.ExtensionMethods {
             //Always parse flags, mimic Enum.Parse behavior. 
             long num = 0;
             bool parsedSomething = false;
-            string[] parts = value.Split(',');
+            string[] parts = value.Split(ParseUtils.Comma);
             for (int i = 0; i < parts.Length; i++) {
                 string p = parts[i].Trim();
                 if (p.Length == 0) continue;

--- a/Core/ExtensionMethods/NameValueCollection.cs
+++ b/Core/ExtensionMethods/NameValueCollection.cs
@@ -148,10 +148,10 @@ namespace ImageResizer.ExtensionMethods {
         /// <returns></returns>
         public static T[] ParseList<T>(string text, T? fallbackValue, params int[] allowedSizes) where T : struct, IConvertible {
             if (text == null) return null;
-            text = text.Trim(' ', '(', ')', ','); //Trim parenthesis, commas, and spaces
+            text = text.Trim(ParseUtils.ListParts); //Trim parenthesis, commas, and spaces
             if (text.Length == 0) return null;
 
-            string[] parts = text.Split(new char[] { ',' }, StringSplitOptions.None);
+            string[] parts = text.Split(ParseUtils.Comma, StringSplitOptions.None);
 
             //Verify the array is of an accepted size if any are specified
             bool foundCount = allowedSizes.Length == 0;

--- a/Core/InterceptModule.cs
+++ b/Core/InterceptModule.cs
@@ -102,7 +102,7 @@ namespace ImageResizer {
 
                     // no user (must be anonymous...).. Or authentication doesn't work for this suffix. Whatever, just avoid a nullref in the UrlAuthorizationModule
                     if (user == null)
-                        user = new GenericPrincipal(new GenericIdentity(string.Empty, string.Empty), new string[0]);
+                        user = new GenericPrincipal(new GenericIdentity(string.Empty, string.Empty), ParseUtils.EmptyStringArray);
 
                     //Do we have permission to call UrlAuthorizationModule.CheckUrlAccessForPrincipal?
                     bool canCheckUrl = System.Security.SecurityManager.IsGranted(new System.Security.Permissions.SecurityPermission(System.Security.Permissions.PermissionState.Unrestricted));
@@ -227,7 +227,7 @@ namespace ImageResizer {
             //Determine the file extenson for the caching system to use if we aren't processing the image
             //Use the exsiting one if is an image extension. If not, use "unknown". 
             // We don't want to suggest writing .exe or .aspx files to the cache! 
-            string fallbackExtension = PathUtils.GetFullExtension(virtualPath).TrimStart('.'); 
+            string fallbackExtension = PathUtils.GetFullExtension(virtualPath).TrimStart(ParseUtils.Period); 
             if (!conf.IsAcceptedImageType(virtualPath)) fallbackExtension = "unknown";
 
             //Determine the mime-type if we aren't processing the image.

--- a/Core/Plugins/Basic/DefaultEncoder.cs
+++ b/Core/Plugins/Basic/DefaultEncoder.cs
@@ -10,6 +10,7 @@ using ImageResizer.Plugins;
 using ImageResizer.Encoding;
 using ImageResizer.Resizing;
 using System.Globalization;
+using ImageResizer.Util;
 
 namespace ImageResizer.Plugins.Basic {
     /// <summary>
@@ -232,7 +233,7 @@ namespace ImageResizer.Plugins.Basic {
         {
             if (string.IsNullOrEmpty(ext)) return null;
             lock (_syncExts) {
-                ext = ext.Trim(' ', '.').ToLowerInvariant();
+                ext = ext.Trim(ParseUtils.SpaceOrPeriod).ToLowerInvariant();
                 if (!imageExtensions.ContainsKey(ext)) return null;
                 return imageExtensions[ext];
             }
@@ -244,12 +245,12 @@ namespace ImageResizer.Plugins.Basic {
         /// <param name="matchingFormat"></param>
         private static void addImageExtension(string extension, ImageFormat matchingFormat) {
             //In case first call is to this method, use the property. Will be recursive, but that's fine, since it won't be null.
-            imageExtensions.Add(extension.TrimStart('.', ' ').ToLowerInvariant(), matchingFormat);
+            imageExtensions.Add(extension.TrimStart(ParseUtils.SpaceOrPeriod).ToLowerInvariant(), matchingFormat);
         }
 
         public static void AddImageExtension(string extension, ImageFormat matchingFormat){
             lock (_syncExts) {//In case first call is to this method, use the property. Will be recursive, but that's fine, since it won't be null.
-                imageExtensions.Add(extension.TrimStart('.', ' ').ToLowerInvariant(), matchingFormat);
+                imageExtensions.Add(extension.TrimStart(ParseUtils.SpaceOrPeriod).ToLowerInvariant(), matchingFormat);
             }
         }
 

--- a/Core/Plugins/Basic/DiagnosticPageHandler.cs
+++ b/Core/Plugins/Basic/DiagnosticPageHandler.cs
@@ -91,7 +91,7 @@ namespace ImageResizer.Plugins.Basic {
                     groups += "\n" + v + " assemblies: ";
                     foreach(string a in versions[v])
                         groups += a + ", ";
-                    groups = groups.TrimEnd(' ', ',');
+                    groups = groups.TrimEnd(ParseUtils.SpaceOrComma);
                 }
                 issues.Add(new Issue("Potentially incompatible ImageResizer assemblies were detected.",
                     "Please make sure all ImageResizer assemblies are from the same version. Compatibility issues are possible if you mix plugins from different releases." + groups, IssueSeverity.Warning));

--- a/Core/Plugins/Basic/Image404.cs
+++ b/Core/Plugins/Basic/Image404.cs
@@ -267,7 +267,7 @@ namespace ImageResizer.Plugins.Basic {
             }
             //4 Otherwise, join with image404.basedir or the application root
             string baseDir = c.get("image404.basedir","~/");
-            path = baseDir.TrimEnd('/') + '/' + path.TrimStart('/');
+            path = baseDir.TrimEnd(ParseUtils.ForwardSlash) + '/' + path.TrimStart(ParseUtils.ForwardSlash);
             return path;
         }
 
@@ -294,7 +294,7 @@ namespace ImageResizer.Plugins.Basic {
                     return MatcherCollection.Empty;
                 }
 
-                var commands = commandList.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                var commands = commandList.Split(ParseUtils.Comma, StringSplitOptions.RemoveEmptyEntries);
                 var matchers = new Matcher[commands.Length];
 
                 for (var i = 0; i < commands.Length; i++)

--- a/Core/Plugins/Basic/ImageHandlerSyntax.cs
+++ b/Core/Plugins/Basic/ImageHandlerSyntax.cs
@@ -4,6 +4,7 @@ using System.Text;
 using ImageResizer.Configuration;
 using System.Web.Hosting;
 using System.Collections.Specialized;
+using ImageResizer.Util;
 
 namespace ImageResizer.Plugins.Basic {
     /// <summary>
@@ -26,7 +27,7 @@ namespace ImageResizer.Plugins.Basic {
         }
 
         void Pipeline_PostAuthorizeRequestStart(System.Web.IHttpModule sender, System.Web.HttpContext context) {
-            string prefix = HostingEnvironment.ApplicationVirtualPath.TrimEnd('/') + '/';
+            string prefix = HostingEnvironment.ApplicationVirtualPath.TrimEnd(ParseUtils.ForwardSlash) + '/';
 
             if (c.Pipeline.PreRewritePath.Equals(prefix + "ImageHandler.ashx", StringComparison.OrdinalIgnoreCase) &&
                 !string.IsNullOrEmpty(context.Request.QueryString["src"])) {

--- a/Core/Plugins/Basic/Presets.cs
+++ b/Core/Plugins/Basic/Presets.cs
@@ -6,6 +6,7 @@ using ImageResizer.Configuration;
 using ImageResizer.Configuration.Issues;
 using System.Collections.Specialized;
 using ImageResizer.ExtensionMethods;
+using ImageResizer.Util;
 
 namespace ImageResizer.Plugins.Basic {
     public class Presets:IPlugin,IQuerystringPlugin, IIssueProvider, ISettingsModifier {
@@ -69,7 +70,7 @@ namespace ImageResizer.Plugins.Basic {
 
         void ApplyPreset(IUrlEventArgs e, Dictionary<string, ResizeSettings> dict) {
             if (!string.IsNullOrEmpty(e.QueryString["preset"])) {
-                string[] presets = e.QueryString["preset"].Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                string[] presets = e.QueryString["preset"].Split(ParseUtils.Comma, StringSplitOptions.RemoveEmptyEntries);
                 foreach (string p in presets) {
                     if (!dict.ContainsKey(p)) continue;
                     ResizeSettings query = dict[p];
@@ -82,7 +83,7 @@ namespace ImageResizer.Plugins.Basic {
 
         public ResizeSettings Modify(ResizeSettings s) {
             if (!string.IsNullOrEmpty(s["preset"])) {
-                string[] presets = s["preset"].Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                string[] presets = s["preset"].Split(ParseUtils.Comma, StringSplitOptions.RemoveEmptyEntries);
                 foreach (string p in presets) {
                     //Apply defaults
                     if (defaults.ContainsKey(p)) {

--- a/Core/Plugins/Basic/VirtualFolder.cs
+++ b/Core/Plugins/Basic/VirtualFolder.cs
@@ -109,7 +109,7 @@ namespace ImageResizer.Plugins.Basic {
         /// <param name="path"></param>
         /// <returns></returns>
         protected string normalizeVirtualPath(string path) {
-            if (!path.StartsWith("/")) path = HostingEnvironment.ApplicationVirtualPath.TrimEnd('/') + '/' + (path.StartsWith("~") ? path.Substring(1) : path).TrimStart('/');
+            if (!path.StartsWith("/")) path = HostingEnvironment.ApplicationVirtualPath.TrimEnd(ParseUtils.ForwardSlash) + '/' + (path.StartsWith("~") ? path.Substring(1) : path).TrimStart(ParseUtils.ForwardSlash);
             return path;
         }
         /// <summary>
@@ -174,7 +174,7 @@ namespace ImageResizer.Plugins.Basic {
         public string LocalMapPath(string virtualPath) {
             virtualPath = normalizeVirtualPath(virtualPath);
             if (virtualPath.StartsWith(this.VirtualPath, StringComparison.OrdinalIgnoreCase)) {
-                return Path.Combine(PhysicalPath, virtualPath.Substring(this.VirtualPath.Length).TrimStart('/').Replace('/', Path.DirectorySeparatorChar));
+                return Path.Combine(PhysicalPath, virtualPath.Substring(this.VirtualPath.Length).TrimStart(ParseUtils.ForwardSlash).Replace('/', Path.DirectorySeparatorChar));
             }
             return null;
         }

--- a/Core/Util/ParseUtils.cs
+++ b/Core/Util/ParseUtils.cs
@@ -17,6 +17,29 @@ namespace ImageResizer.Util {
         public const NumberStyles FloatingPointStyle = NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite |
             NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint | NumberStyles.AllowThousands | NumberStyles.AllowExponent;
 
+        public static readonly char[] Comma = new char[] { ',' };
+        public static readonly char[] Period = new char[] { '.' };
+        public static readonly char[] EqualSign = new char[] { '=' };
+        public static readonly char[] VBar = new char[] { '|' };
+        public static readonly char[] Octothorpe = new char[] { '#' };
+        public static readonly char[] Ampersand = new char[] { '&' };
+        public static readonly char[] Asterisk = new char[] { '*' };
+        public static readonly char[] DoubleQuote = new char[] { '"' };
+        public static readonly char[] QueryOrFragment = new char[] { '?', '#' };
+        public static readonly char[] QueryPartsWithSemi = new char[] { '?', '&', ';' };
+        public static readonly char[] QueryParts = new char[] { '?', '&' };
+        public static readonly char[] ForwardSlash = new char[] { '/' };
+        public static readonly char[] BackSlash = new char[] { '\\' };
+        public static readonly char[] ForwardSlashOrTilde = new char[] { '/', '~' };
+        public static readonly char[] Slashes = new char[] { '/', '\\' };
+        public static readonly char[] SpaceOrSlashes = new char[] { ' ', '/', '\\' };
+        public static readonly char[] SpaceOrPeriod = new char[] { ' ', '.' };
+        public static readonly char[] SpaceOrComma = new char[] { ' ', ',' };
+        public static readonly char[] ListNoise = new char[] { ' ', '(', ')' };
+        public static readonly char[] ListParts = new char[] { ' ', '(', ')', ',' };
+        public static readonly char[] PathParts = new char[] { '.', '/', ' ', '\\', '?', '&', ':' };
+        public static readonly char[] VirtualPathParts = new char[] { '/', '\\', '~' };
+        public static readonly string[] EmptyStringArray = new string[0];
 
         public static Color ParseColor(string value, Color defaultValue) {
             Color? c = ParseColor(value);
@@ -24,7 +47,7 @@ namespace ImageResizer.Util {
         }
         public static Color? ParseColor(string value) {
             if (string.IsNullOrEmpty(value)) return null;
-            value = value.TrimStart('#');
+            value = value.TrimStart(Octothorpe);
             //try hex first
             int val;
             if (int.TryParse(value, System.Globalization.NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out val)) {
@@ -50,7 +73,7 @@ namespace ImageResizer.Util {
         public static string SerializeColor(Color value) {
             string text = System.Drawing.ColorTranslator.ToHtml(value);
             if (text.StartsWith("#")) {
-                text = text.TrimStart('#');
+                text = text.TrimStart(Octothorpe);
                 if (value.A != 255) text += value.A.ToString("X2", NumberFormatInfo.InvariantInfo);
             }
             return text;

--- a/Core/Util/PathUtils.cs
+++ b/Core/Util/PathUtils.cs
@@ -33,8 +33,6 @@ namespace ImageResizer.Util {
             }
         }
 
-        private static readonly char[] QueryOrFragment = new char[] { '?', '#' };
-        private static readonly char[] SpaceOrSlash = new char[] { ' ', '/', '\\' };
         /// <summary>
         /// Should be called SetFullExtension.
         /// Sets the file extension of the specified path to the specified value, returning the result.
@@ -46,14 +44,14 @@ namespace ImageResizer.Util {
         /// <param name="newExtension"></param>
         /// <returns></returns>
         public static string SetExtension(string path, string newExtension) {
-            int query = path.IndexOfAny(QueryOrFragment);
+            int query = path.IndexOfAny(ParseUtils.QueryOrFragment);
             if (query < 0) query = path.Length;
             //Finds the first character that could possibly be part of the extension (before the query)
-            int firstPossibleExtensionChar = path.LastIndexOfAny(SpaceOrSlash, query - 1) + 1;
+            int firstPossibleExtensionChar = path.LastIndexOfAny(ParseUtils.SpaceOrSlashes, query - 1) + 1;
             int extensionStarts = path.IndexOf('.', firstPossibleExtensionChar, query - firstPossibleExtensionChar);
             if (extensionStarts < 0) extensionStarts = query;
 
-            return path.Substring(0, extensionStarts) + (!string.IsNullOrEmpty(newExtension) ? "." + newExtension.TrimStart('.') : "") + path.Substring(query);
+            return path.Substring(0, extensionStarts) + (!string.IsNullOrEmpty(newExtension) ? "." + newExtension.TrimStart(ParseUtils.Period) : "") + path.Substring(query);
 
         }
 
@@ -64,10 +62,10 @@ namespace ImageResizer.Util {
         /// <param name="path"></param>
         /// <returns></returns>
         public static string RemoveFullExtension(string path) {
-            int query = path.IndexOfAny(QueryOrFragment);
+            int query = path.IndexOfAny(ParseUtils.QueryOrFragment);
             if (query < 0) query = path.Length;
             //Finds the first character that could possibly be part of the extension (before the query)
-            int firstPossibleExtensionChar = path.LastIndexOfAny(SpaceOrSlash, query - 1) + 1;
+            int firstPossibleExtensionChar = path.LastIndexOfAny(ParseUtils.SpaceOrSlashes, query - 1) + 1;
             int extensionStarts = path.IndexOf('.', firstPossibleExtensionChar, query - firstPossibleExtensionChar);
             if (extensionStarts < 0) extensionStarts = query;
 
@@ -83,10 +81,10 @@ namespace ImageResizer.Util {
         /// <param name="path"></param>
         /// <returns></returns>
         public static string RemoveExtension(string path) {
-            int query = path.IndexOfAny(QueryOrFragment);
+            int query = path.IndexOfAny(ParseUtils.QueryOrFragment);
             if (query < 0) query = path.Length;
             //Finds the first character that could possibly be part of the extension (before the query)
-            int firstPossibleExtensionChar = path.LastIndexOfAny(SpaceOrSlash, query - 1) + 1;
+            int firstPossibleExtensionChar = path.LastIndexOfAny(ParseUtils.SpaceOrSlashes, query - 1) + 1;
             int extensionStarts = path.LastIndexOf('.', query - 1, query - firstPossibleExtensionChar);
             if (extensionStarts < 0) extensionStarts = query;
 
@@ -102,9 +100,9 @@ namespace ImageResizer.Util {
         /// <param name="newExtension"></param>
         /// <returns></returns>
         public static string AddExtension(string path, string newExtension) {
-            int query = path.IndexOfAny(QueryOrFragment);
+            int query = path.IndexOfAny(ParseUtils.QueryOrFragment);
             if (query < 0) query = path.Length;
-            return path.Substring(0, query) + "." + newExtension.TrimStart('.') + path.Substring(query);
+            return path.Substring(0, query) + "." + newExtension.TrimStart(ParseUtils.Period) + path.Substring(query);
         }
         /// <summary>
         /// Will return the full extension, like ".jpg.ashx", not just the last bit. 
@@ -114,10 +112,10 @@ namespace ImageResizer.Util {
         /// <param name="path"></param>
         /// <returns></returns>
         public static string GetFullExtension(string path) {
-            int query = path.IndexOfAny(QueryOrFragment);
+            int query = path.IndexOfAny(ParseUtils.QueryOrFragment);
             if (query < 0) query = path.Length;
             //Finds the first character that could possibly be part of the extension (before the query)
-            int firstPossibleExtensionChar = path.LastIndexOfAny(SpaceOrSlash, query - 1) + 1;
+            int firstPossibleExtensionChar = path.LastIndexOfAny(ParseUtils.SpaceOrSlashes, query - 1) + 1;
             int extensionStarts = path.IndexOf('.', firstPossibleExtensionChar, query - firstPossibleExtensionChar);
             if (extensionStarts < 0) extensionStarts = query;
 
@@ -132,10 +130,10 @@ namespace ImageResizer.Util {
         /// <param name="path"></param>
         /// <returns></returns>
         public static string GetExtension(string path) {
-            int query = path.IndexOfAny(QueryOrFragment);
+            int query = path.IndexOfAny(ParseUtils.QueryOrFragment);
             if (query < 0) query = path.Length;
             //Finds the first character that could possibly be part of the extension (before the query)
-            int firstPossibleExtensionChar = path.LastIndexOfAny(SpaceOrSlash, query - 1) + 1;
+            int firstPossibleExtensionChar = path.LastIndexOfAny(ParseUtils.SpaceOrSlashes, query - 1) + 1;
             int extensionStarts = path.LastIndexOf('.', query -1, query - firstPossibleExtensionChar );
             if (extensionStarts < 0) extensionStarts = query;
 
@@ -149,7 +147,7 @@ namespace ImageResizer.Util {
         /// <returns></returns>
         public static string ResolveAppRelative(string virtualPath) {
             //resolve tilde
-            if (virtualPath.StartsWith("~", StringComparison.OrdinalIgnoreCase)) return HostingEnvironment.ApplicationVirtualPath.TrimEnd('/') + '/' + virtualPath.TrimStart('~', '/');
+            if (virtualPath.StartsWith("~", StringComparison.OrdinalIgnoreCase)) return HostingEnvironment.ApplicationVirtualPath.TrimEnd(ParseUtils.ForwardSlash) + '/' + virtualPath.TrimStart(ParseUtils.ForwardSlashOrTilde);
             return virtualPath;
         }
 
@@ -161,8 +159,8 @@ namespace ImageResizer.Util {
         /// <returns></returns>
         public static string ResolveAppRelativeAssumeAppRelative(string virtualPath) {
 
-            if (virtualPath.StartsWith("~")) return HostingEnvironment.ApplicationVirtualPath.TrimEnd('/') + "/" + virtualPath.TrimStart('~', '/');
-            if (!virtualPath.StartsWith("/")) return HostingEnvironment.ApplicationVirtualPath.TrimEnd('/') + "/" + virtualPath;
+            if (virtualPath.StartsWith("~")) return HostingEnvironment.ApplicationVirtualPath.TrimEnd(ParseUtils.ForwardSlash) + "/" + virtualPath.TrimStart(ParseUtils.ForwardSlashOrTilde);
+            if (!virtualPath.StartsWith("/")) return HostingEnvironment.ApplicationVirtualPath.TrimEnd(ParseUtils.ForwardSlash) + "/" + virtualPath;
             return virtualPath;
         }
 
@@ -185,10 +183,10 @@ namespace ImageResizer.Util {
                 virtualPath = virtualPath.Substring(0, fragment);
             }
 
-            if (virtualPath.IndexOf('?') > -1) virtualPath = virtualPath.TrimEnd('&') + '&';
+            if (virtualPath.IndexOf('?') > -1) virtualPath = virtualPath.TrimEnd(ParseUtils.Ampersand) + '&';
             else virtualPath += '?';
 
-            return virtualPath + querystring.TrimStart('&', '?') + suffix;
+            return virtualPath + querystring.TrimStart(ParseUtils.QueryParts) + suffix;
         }
 
         /// <summary>
@@ -374,7 +372,7 @@ namespace ImageResizer.Util {
         public static NameValueCollection ParseQueryString(string path, bool allowSemicolons, out string beforeQuery, out string fragment) {
             //Separate the fragment if it's present, and restore it later
             int frag = path.IndexOf('#');
-            if (frag < 0) fragment = "";
+            if (frag < 0) fragment = String.Empty;
             else {
                 fragment = path.Substring(frag);
                 path = path.Substring(0, frag);
@@ -406,13 +404,13 @@ namespace ImageResizer.Util {
         /// <param name="urlDecode"></param>
         /// <returns></returns>
         public static NameValueCollection ParseQueryOnly(string query, bool allowSemicolons = true, bool urlDecode = true) {
-            string[] pairs = query.Split(allowSemicolons ? new char[] { '?', '&', ';' } : new char[] { '?', '&' }, StringSplitOptions.RemoveEmptyEntries);
+            string[] pairs = query.Split(allowSemicolons ? ParseUtils.QueryPartsWithSemi : ParseUtils.QueryParts, StringSplitOptions.RemoveEmptyEntries);
             NameValueCollection c = new NameValueCollection();
             foreach (string s in pairs) {
-                string[] namevalue = s.Split(new char[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
+                string[] namevalue = s.Split(ParseUtils.EqualSign, StringSplitOptions.RemoveEmptyEntries);
                 if (namevalue.Length > 2) {
                     //Handle &key=value=value and &key===value=value -> key : "value=value"
-                    string value = s.Substring(s.IndexOf('=')).TrimStart('=');
+                    string value = s.Substring(s.IndexOf('=')).TrimStart(ParseUtils.EqualSign);
                     c[urlDecode ? HttpUtility.UrlDecode(namevalue[0]) : namevalue[0]] =
                         urlDecode ? HttpUtility.UrlDecode(value) : value;
                 } else if (namevalue.Length == 2) {
@@ -503,7 +501,7 @@ namespace ImageResizer.Util {
             //If it's a match, strip it and convert it to a virtual path.
             if (path.StartsWith(appPath, StringComparison.OrdinalIgnoreCase)) {
                 //Convert to app-relative path missing the ~/
-                path = path.Remove(0, appPath.Length).TrimStart(new char[] { '/', '\\', '~' }).Replace('\\', '/');
+                path = path.Remove(0, appPath.Length).TrimStart(ParseUtils.VirtualPathParts).Replace('\\', '/');
                 return PathUtils.ResolveAppRelativeAssumeAppRelative(path);
                 
             }

--- a/Core/Util/Utils.cs
+++ b/Core/Util/Utils.cs
@@ -14,7 +14,6 @@ using ImageResizer.ExtensionMethods;
 namespace ImageResizer.Util {
     [Obsolete("All methods of this class have been deprecated. Use ParseUtils or ImageResizer.ExtensionMethods instead.  Will be removed in V3.5 or V4.")]
     public class Utils {
-        
   
         public static Color parseColor(string value, Color defaultValue) {
             return ParseUtils.ParseColor(value, defaultValue);
@@ -30,8 +29,8 @@ namespace ImageResizer.Util {
         /// <param name="defaultValue"></param>
         /// <returns></returns>
         public static double[] parseList(string text, double defaultValue) {
-            text = text.Trim(' ', '(', ')');
-            string[] parts = text.Split(new char[] { ',' }, StringSplitOptions.None);
+            text = text.Trim(ParseUtils.ListNoise);
+            string[] parts = text.Split(ParseUtils.Comma, StringSplitOptions.None);
             double[] vals = new double[parts.Length];
             for (int i = 0; i < parts.Length; i++) {
                 if (!double.TryParse(parts[i], floatingPointStyle, NumberFormatInfo.InvariantInfo, out vals[i]))
@@ -202,10 +201,13 @@ namespace ImageResizer.Util {
             if (mode == CropMode.Auto) return "auto";
             if (mode == CropMode.None) return "none";
             if (mode == CropMode.Custom) {
-                string c = "(";
+                var sb = new StringBuilder();
+                sb.Append('(');
                 foreach (double d in coords)
-                    c += d.ToString(NumberFormatInfo.InvariantInfo) + ",";
-                return c.TrimEnd(',') + ")";
+                    sb.Append(d.ToString(NumberFormatInfo.InvariantInfo)).Append(',');
+                if (sb.Length > 1) sb.Length--; // trim trailing comma
+                sb.Append(')');
+                return sb.ToString();
             }
             throw new NotImplementedException("Unrecognized CropMode value: " + mode.ToString());
         }

--- a/Plugins/AzureReader/AzureReader.cs
+++ b/Plugins/AzureReader/AzureReader.cs
@@ -106,7 +106,7 @@ namespace ImageResizer.Plugins.AzureReader {
             if (e.VirtualPath.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) && e.QueryString.Count == 0) {
 
                 // Strip prefix from virtual path; keep container and blob
-                string relativeBlobURL = e.VirtualPath.Substring(vPath.Length -1).Trim('/', '\\');
+                string relativeBlobURL = e.VirtualPath.Substring(vPath.Length -1).Trim(ParseUtils.Slashes);
 
                 // Redirect to blob
                 context.Response.Redirect(blobStorageEndpoint + relativeBlobURL);

--- a/Plugins/AzureReader/AzureVirtualPathProvider.cs
+++ b/Plugins/AzureReader/AzureVirtualPathProvider.cs
@@ -98,7 +98,7 @@ namespace ImageResizer.Plugins.AzureReader {
                 if (LazyExistenceCheck) return true;
 
                 // Strip prefix from virtual path; keep container and blob
-                string relativeBlobURL = virtualPath.Substring(VirtualFilesystemPrefix.Length).Trim('/', '\\');
+                string relativeBlobURL = virtualPath.Substring(VirtualFilesystemPrefix.Length).Trim(ParseUtils.Slashes);
 
                 // Get a reference to the blob
                 CloudBlob cloudBlob = CloudBlobClient.GetBlobReference(relativeBlobURL);
@@ -120,7 +120,7 @@ namespace ImageResizer.Plugins.AzureReader {
         public IVirtualFile GetFile(string virtualPath, System.Collections.Specialized.NameValueCollection queryString) {
             if (IsPathVirtual(virtualPath)) {
                 // Strip prefix from virtual path; keep container and blob
-                string relativeBlobURL = virtualPath.Substring(VirtualFilesystemPrefix.Length).Trim('/', '\\');
+                string relativeBlobURL = virtualPath.Substring(VirtualFilesystemPrefix.Length).Trim(ParseUtils.Slashes);
 
 
                 try {

--- a/Plugins/AzureReader2/AzureFile.cs
+++ b/Plugins/AzureReader2/AzureFile.cs
@@ -2,6 +2,7 @@
 using System;
 using System.IO;
 using System.Web.Hosting;
+using ImageResizer.Util;
 using Microsoft.WindowsAzure;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
@@ -28,7 +29,7 @@ namespace ImageResizer.Plugins.AzureReader2 {
             try {
                 // Get a reference to the blob
                 // mb: 12/8/2012 - the path needs to be a uri now, so combining blobclient baseuri with the virtualpath
-                Uri blobUri = new Uri(string.Format("{0}/{1}", parent.CloudBlobClient.BaseUri.OriginalString.TrimEnd('/', '\\'), VirtualPath));
+                Uri blobUri = new Uri(string.Format("{0}/{1}", parent.CloudBlobClient.BaseUri.OriginalString.TrimEnd(ParseUtils.Slashes), VirtualPath));
                 ICloudBlob cloudBlob = parent.CloudBlobClient.GetBlobReferenceFromServer(blobUri);
 
                 cloudBlob.DownloadToStream(ms);

--- a/Plugins/AzureReader2/AzureReader.cs
+++ b/Plugins/AzureReader2/AzureReader.cs
@@ -106,7 +106,7 @@ namespace ImageResizer.Plugins.AzureReader2 {
             if (e.VirtualPath.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) && e.QueryString.Count == 0) {
 
                 // Strip prefix from virtual path; keep container and blob
-                string relativeBlobURL = e.VirtualPath.Substring(prefix.Length).TrimStart('/', '\\');
+                string relativeBlobURL = e.VirtualPath.Substring(prefix.Length).TrimStart(ParseUtils.Slashes);
 
                 // Redirect to blob
                 context.Response.Redirect(blobStorageEndpoint + relativeBlobURL);

--- a/Plugins/AzureReader2/AzureVirtualPathProvider.cs
+++ b/Plugins/AzureReader2/AzureVirtualPathProvider.cs
@@ -117,7 +117,7 @@ namespace ImageResizer.Plugins.AzureReader2 {
                 try {
                     // Strip prefix from virtual path; keep container and blob
                     // mb:12/8/2012 - need to prepend the blob client base uri to the url
-                    string relativeBlobURL = string.Format("{0}/{1}", CloudBlobClient.BaseUri.OriginalString.TrimEnd('/', '\\'), virtualPath.Substring(VirtualFilesystemPrefix.Length).Trim('/', '\\'));
+                    string relativeBlobURL = string.Format("{0}/{1}", CloudBlobClient.BaseUri.OriginalString.TrimEnd(ParseUtils.Slashes), virtualPath.Substring(VirtualFilesystemPrefix.Length).Trim(ParseUtils.Slashes));
 
                     // Get a reference to the blob
                     // mb:12/8/2012 - this call now must be a uri
@@ -139,14 +139,14 @@ namespace ImageResizer.Plugins.AzureReader2 {
         public IVirtualFile GetFile(string virtualPath, System.Collections.Specialized.NameValueCollection queryString) {
             if (IsPathVirtual(virtualPath)) {
                 // Strip prefix from virtual path; keep container and blob
-                string relativeBlobURL = virtualPath.Substring(VirtualFilesystemPrefix.Length).Trim('/', '\\');
+                string relativeBlobURL = virtualPath.Substring(VirtualFilesystemPrefix.Length).Trim(ParseUtils.Slashes);
 
 
                 try {
                     if (!LazyExistenceCheck) {
                         // Get a reference to the blob
                         // mb: 12/8/2012 - creating uri here to keep the above relativeBlobURL as is to create & return an AzureFile
-                        Uri relativeBlobUri = new Uri(string.Format("{0}/{1}", CloudBlobClient.BaseUri.OriginalString.TrimEnd('/', '\\'), relativeBlobURL));
+                        Uri relativeBlobUri = new Uri(string.Format("{0}/{1}", CloudBlobClient.BaseUri.OriginalString.TrimEnd(ParseUtils.Slashes), relativeBlobURL));
                         ICloudBlob cloudBlob = CloudBlobClient.GetBlobReferenceFromServer(relativeBlobUri);
                         cloudBlob.FetchAttributes();
                     }

--- a/Plugins/DiskCache/Cleanup/CleanupWorker.cs
+++ b/Plugins/DiskCache/Cleanup/CleanupWorker.cs
@@ -9,6 +9,7 @@ using ImageResizer.Configuration.Issues;
 using System.Diagnostics;
 using ImageResizer.Configuration.Logging;
 using System.Globalization;
+using ImageResizer.Util;
 
 namespace ImageResizer.Plugins.DiskCache {
     public class CleanupWorker : IssueSink, IDisposable {
@@ -261,7 +262,7 @@ namespace ImageResizer.Plugins.DiskCache {
         protected string addSlash(string s, bool physical) {
             if (string.IsNullOrEmpty(s)) return s; //On empty or null, dont' add aslash.
             if (physical) return s.TrimEnd(System.IO.Path.DirectorySeparatorChar) + System.IO.Path.DirectorySeparatorChar;
-            else return s.TrimEnd('/') + '/';
+            else return s.TrimEnd(ParseUtils.ForwardSlash) + '/';
         }
 
         protected void PopulateFolder(CleanupWorkItem item, bool recursive) {

--- a/Plugins/DiskCache/CustomDiskCache.cs
+++ b/Plugins/DiskCache/CustomDiskCache.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.Threading;
 using ImageResizer.Plugins.DiskCache.Async;
 using System.Globalization;
+using ImageResizer.Util;
 
 namespace ImageResizer.Plugins.DiskCache {
     public delegate void CacheResultHandler(CustomDiskCache sender, CacheResult r);
@@ -119,7 +120,7 @@ namespace ImageResizer.Plugins.DiskCache {
             string relativePath = new UrlHasher().hash(keyBasis, subfolders, "/") + '.' + extension;
 
             //Physical path
-            string physicalPath = PhysicalCachePath.TrimEnd('\\', '/') + System.IO.Path.DirectorySeparatorChar +
+            string physicalPath = PhysicalCachePath.TrimEnd(ParseUtils.Slashes) + System.IO.Path.DirectorySeparatorChar +
                     relativePath.Replace('/', System.IO.Path.DirectorySeparatorChar);
 
 

--- a/Plugins/DiskCache/DiskCache.cs
+++ b/Plugins/DiskCache/DiskCache.cs
@@ -120,7 +120,7 @@ namespace ImageResizer.Plugins.DiskCache
         }
 
 
-        protected string virtualDir =  HostingEnvironment.ApplicationVirtualPath.TrimEnd('/') + "/imagecache";
+        protected string virtualDir =  HostingEnvironment.ApplicationVirtualPath.TrimEnd(ParseUtils.ForwardSlash) + "/imagecache";
         /// <summary>
         /// Sets the location of the cache directory. 
         /// Can be a virtual path (like /App/imagecache) or an application-relative path (like ~/imagecache, the default).
@@ -300,7 +300,7 @@ namespace ImageResizer.Plugins.DiskCache
             if (r.Data == null) {
 
                 //Calculate the virtual path
-                string virtualPath = VirtualCacheDir.TrimEnd('/') + '/' + r.RelativePath.Replace('\\', '/').TrimStart('/');
+                string virtualPath = VirtualCacheDir.TrimEnd(ParseUtils.ForwardSlash) + '/' + r.RelativePath.Replace('\\', '/').TrimStart(ParseUtils.ForwardSlash);
 
                 //Rewrite to cached, resized image.
                 context.RewritePath(virtualPath, false);

--- a/Plugins/DiskCache/Index/CachedFolder.cs
+++ b/Plugins/DiskCache/Index/CachedFolder.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.IO;
 using System.Diagnostics;
+using ImageResizer.Util;
 
 namespace ImageResizer.Plugins.DiskCache {
     public delegate void FileDisappearedHandler(string relativePath, string physicalPath);
@@ -311,7 +312,7 @@ namespace ImageResizer.Plugins.DiskCache {
             try {
                  dirs = System.IO.Directory.GetDirectories(physicalPath);
             } catch (DirectoryNotFoundException) {
-                dirs = new string[]{}; //Pretend it's empty. We don't care, the next recursive will get rid of it.
+                dirs = ParseUtils.EmptyStringArray; //Pretend it's empty. We don't care, the next recursive will get rid of it.
             }
             lock (_sync) {
                 CachedFolder f = getOrCreateFolder(relativePath, true);
@@ -338,7 +339,7 @@ namespace ImageResizer.Plugins.DiskCache {
             try {
                 physicalFiles = System.IO.Directory.GetFiles(physicalPath);
             } catch (DirectoryNotFoundException) {
-                physicalFiles = new string[] { }; //Pretend it's empty. We don't care, the next recursive will get rid of it.
+                physicalFiles = ParseUtils.EmptyStringArray; //Pretend it's empty. We don't care, the next recursive will get rid of it.
             }
             Dictionary<string, CachedFileInfo> newFiles = new Dictionary<string, CachedFileInfo>(physicalFiles.Length, KeyComparer);
 

--- a/Plugins/DiskCache/SourceDiskCache/SourceDiskCache.cs
+++ b/Plugins/DiskCache/SourceDiskCache/SourceDiskCache.cs
@@ -18,7 +18,7 @@ namespace ImageResizer.Plugins.SourceDiskCache
     {
         public SourceDiskCachePlugin() { }
 
-        protected string virtualDir = HostingEnvironment.ApplicationVirtualPath.TrimEnd('/') + "/cache/sourceimages";
+        protected string virtualDir = HostingEnvironment.ApplicationVirtualPath.TrimEnd(ParseUtils.ForwardSlash) + "/cache/sourceimages";
         /// <summary>
         /// Sets the location of the cache directory. 
         /// Can be a virtual path (like /App/imagecache) or an application-relative path (like ~/imagecache, the default).

--- a/Plugins/DiskCache/WebConfigWriter.cs
+++ b/Plugins/DiskCache/WebConfigWriter.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using ImageResizer.Configuration.Logging;
+using ImageResizer.Util;
 
 namespace ImageResizer.Plugins.DiskCache {
     /// <summary>
@@ -84,7 +85,7 @@ namespace ImageResizer.Plugins.DiskCache {
         /// <param name="physicalPath"></param>
         protected void _checkWebConfig() {
             try {
-                string webConfigPath = physicalDirPath.TrimEnd('/', '\\') + System.IO.Path.DirectorySeparatorChar + "Web.config";
+                string webConfigPath = physicalDirPath.TrimEnd(ParseUtils.Slashes) + System.IO.Path.DirectorySeparatorChar + "Web.config";
                 if (lp.Logger != null) lp.Logger.Debug("Verifying Web.config exists in cache directory.");
                 if (System.IO.File.Exists(webConfigPath)) return; //Already exists, quit
 

--- a/Plugins/FFmpeg/FFmpegManager.cs
+++ b/Plugins/FFmpeg/FFmpegManager.cs
@@ -67,12 +67,12 @@ namespace ImageResizer.Plugins.FFmpeg
                 {
                     if (ffmpegPath == null)
                     {
-                        string m = basePath.TrimEnd('\\') + '\\' + "ffmpeg.exe";
+                        string m = basePath.TrimEnd(ParseUtils.BackSlash) + '\\' + "ffmpeg.exe";
                         if (File.Exists(Path.GetFullPath(m))) ffmpegPath = Path.GetFullPath(m);
                     }
                     if (ffprobePath == null)
                     {
-                        string p = basePath.TrimEnd('\\') + '\\' + "ffprobe.exe";
+                        string p = basePath.TrimEnd(ParseUtils.BackSlash) + '\\' + "ffprobe.exe";
                         if (File.Exists(Path.GetFullPath(p))) ffprobePath = Path.GetFullPath(p);
                     }
 

--- a/Plugins/FFmpeg/FFmpegPlugin.cs
+++ b/Plugins/FFmpeg/FFmpegPlugin.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using ImageResizer.Util;
 
 namespace ImageResizer.Plugins.FFmpeg
 {
@@ -77,8 +78,8 @@ namespace ImageResizer.Plugins.FFmpeg
         {
             var exts = GetSupportedFileExtensions();
 
-            var full = ImageResizer.Util.PathUtils.GetFullExtension(virtualPath).ToLowerInvariant().TrimStart('.');
-            var parts = full.Split('.');
+            var full = ImageResizer.Util.PathUtils.GetFullExtension(virtualPath).ToLowerInvariant().TrimStart(ParseUtils.Period);
+            var parts = full.Split(ParseUtils.Period);
             if (parts.Length < 1) return false;
             //Only accept the file if our querystring is on it.
             if (exts.Contains(parts[parts.Length - 1]))

--- a/Plugins/Faces/FacesPlugin.cs
+++ b/Plugins/Faces/FacesPlugin.cs
@@ -43,9 +43,13 @@ namespace ImageResizer.Plugins.Faces {
             var faces = GetFacesFromImage(image, settings);
             StringBuilder sb = new StringBuilder();
             foreach (Face f in faces)
-                sb.Append(f.X + "," + f.Y + "," + f.X2 + "," + f.Y2 + "," + f.Accuracy + ",");
-
-            return sb.ToString().TrimEnd(',');
+                sb.Append(f.X.ToString(NumberFormatInfo.InvariantInfo)).Append(',')
+                    .Append(f.Y.ToString(NumberFormatInfo.InvariantInfo)).Append(',')
+                    .Append(f.X2.ToString(NumberFormatInfo.InvariantInfo)).Append(',')
+                    .Append(f.Y2.ToString(NumberFormatInfo.InvariantInfo)).Append(',')
+                    .Append(f.Accuracy.ToString(NumberFormatInfo.InvariantInfo)).Append(',');
+            if (sb.Length > 0) sb.Length--; // trim trailing comma
+            return sb.ToString();
         }
 
         /// <summary>

--- a/Plugins/Faces/FeatureDetectionBase.cs
+++ b/Plugins/Faces/FeatureDetectionBase.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Drawing;
 using OpenCvSharp;
 using System.IO;
+using ImageResizer.Util;
 
 namespace ImageResizer.Plugins.Faces {
     public static class OpenCvExtensions {
@@ -67,7 +68,7 @@ namespace ImageResizer.Plugins.Faces {
             foreach (string key in fileNames.Keys) {
                 string resolvedPath = null;
                 foreach (string basePath in searchFolders) {
-                    string full = basePath.TrimEnd('\\') + '\\' + fileNames[key];
+                    string full = basePath.TrimEnd(ParseUtils.BackSlash) + '\\' + fileNames[key];
                     if (File.Exists(Path.GetFullPath(full))) {
                         resolvedPath = Path.GetFullPath(full);
                         //An ExecutionException will occur here if multiple OpenCv instances are loaded

--- a/Plugins/FreeImage/FreeImageDecoder.cs
+++ b/Plugins/FreeImage/FreeImageDecoder.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Diagnostics;
 using System.Globalization;
 using ImageResizer.ExtensionMethods;
+using ImageResizer.Util;
 
 namespace ImageResizer.Plugins.FreeImageDecoder {
 
@@ -37,7 +38,7 @@ namespace ImageResizer.Plugins.FreeImageDecoder {
             List<string> extensions = new List<string>();
             foreach (FREE_IMAGE_FORMAT format in formats)
                 if (format != FREE_IMAGE_FORMAT.FIF_UNKNOWN)
-                    extensions.AddRange(FreeImage.GetFIFExtensionList(format).Split(','));
+                    extensions.AddRange(FreeImage.GetFIFExtensionList(format).Split(ParseUtils.Comma));
             return extensions;
 
         }
@@ -48,7 +49,7 @@ namespace ImageResizer.Plugins.FreeImageDecoder {
         }
 
         public IEnumerable<string> GetSupportedFileExtensions() {
-            if (supportedExts == null) return new string[] { };
+            if (supportedExts == null) return ParseUtils.EmptyStringArray;
             else return supportedExts;
         }
 

--- a/Plugins/LicenseVerifier/DomainLicense.cs
+++ b/Plugins/LicenseVerifier/DomainLicense.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Text;
+using ImageResizer.Util;
 
 namespace ImageResizer.Plugins.LicenseVerifier {
     public class DomainLicense {
@@ -39,7 +40,7 @@ namespace ImageResizer.Plugins.LicenseVerifier {
                     case "expires": Expires = DateTime.Parse(value); break;
                     case "features":
                         var ids = new List<Guid>();
-                        string[] parts = value.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                        string[] parts = value.Split(ParseUtils.Comma, StringSplitOptions.RemoveEmptyEntries);
                         foreach (string p in parts) {
                             ids.Add(new Guid(p));
                         }
@@ -81,8 +82,9 @@ namespace ImageResizer.Plugins.LicenseVerifier {
         private string Join(ICollection<Guid> items) {
             var sb = new StringBuilder();
             foreach (Guid g in items)
-                sb.Append(g.ToString() + ",");
-            return sb.ToString().TrimEnd(',');
+                sb.Append(g.ToString()).Append(',');
+            if (sb.Length > 0) sb.Length--; // discard trailing comma
+            return sb.ToString();
         }
 
         private string Decrypt(byte[] encrypted) {

--- a/Plugins/PsdComposer/PsdCommandBuilder.cs
+++ b/Plugins/PsdComposer/PsdCommandBuilder.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Drawing;
 using System.Collections.Specialized;
 using System.Globalization;
+using ImageResizer.Util;
 
 namespace ImageResizer.Plugins.PsdComposer
 {
@@ -46,7 +47,7 @@ namespace ImageResizer.Plugins.PsdComposer
         public Dictionary<string, Color> parseColorDict(string str)
         {
             if (string.IsNullOrEmpty(str)) return new Dictionary<string, System.Drawing.Color>();
-            string[] parts = str.Trim('|').Split('|');
+            string[] parts = str.Trim(ParseUtils.VBar).Split(ParseUtils.VBar);
             
             if (parts.Length % 2 != 0) throw new ArgumentException("Invalid string! Must have an even number of parts.");
             Dictionary<string, Color> dict = new Dictionary<string, Color>();
@@ -63,9 +64,9 @@ namespace ImageResizer.Plugins.PsdComposer
             foreach (KeyValuePair<string, Color> p in dict)
             {
                 sb.Append(Base64UrlEncode(p.Key));
-                sb.Append("|");
+                sb.Append('|');
                 sb.Append(p.Value.ToArgb().ToString("x", NumberFormatInfo.InvariantInfo));
-                sb.Append("|");
+                sb.Append('|');
             }
             return sb.ToString();
         }
@@ -73,7 +74,7 @@ namespace ImageResizer.Plugins.PsdComposer
         {
             if (string.IsNullOrEmpty(str)) return new Dictionary<string, string>();
             if (str.EndsWith("|")) str = str.Substring(0, str.Length - 1);
-            string[] parts = str.Split(new char[]{'|'},StringSplitOptions.None);
+            string[] parts = str.Split(ParseUtils.VBar, StringSplitOptions.None);
 
             if (parts.Length % 2 != 0) throw new ArgumentException("Invalid string! Must have an even number of parts.");
             Dictionary<string, string> dict = new Dictionary<string, string>();
@@ -90,9 +91,9 @@ namespace ImageResizer.Plugins.PsdComposer
             foreach (KeyValuePair<string, string> p in dict)
             {
                 sb.Append(Base64UrlEncode(p.Key));
-                sb.Append("|");
+                sb.Append('|');
                 sb.Append(Base64UrlEncode(p.Value != null ? p.Value : ""));
-                sb.Append("|");
+                sb.Append('|');
             }
             return sb.ToString();
         }
@@ -101,7 +102,7 @@ namespace ImageResizer.Plugins.PsdComposer
         public Dictionary<string, bool> parseBooleanDict(string str)
         {
             if (string.IsNullOrEmpty(str)) return new Dictionary<string, bool>();
-            string[] parts = str.Trim('|').Split('|');
+            string[] parts = str.Trim(ParseUtils.VBar).Split(ParseUtils.VBar);
             if (parts.Length % 2 != 0) throw new ArgumentException("Invalid string! Must have an even number of parts.");
             Dictionary<string, bool> dict = new Dictionary<string, bool>();
 
@@ -119,9 +120,9 @@ namespace ImageResizer.Plugins.PsdComposer
             foreach (KeyValuePair<string, bool> p in dict)
             {
                 sb.Append(Base64UrlEncode(p.Key));
-                sb.Append("|");
-                sb.Append(p.Value ? "1" : "0");
-                sb.Append("|");
+                sb.Append('|');
+                sb.Append(p.Value ? '1' : '0');
+                sb.Append('|');
             }
             return sb.ToString();
         }
@@ -236,7 +237,7 @@ namespace ImageResizer.Plugins.PsdComposer
             {
                 if (s.Equals("*")) return s; //Only used by unit tests
 
-                string trimmed = s.Trim('*');
+                string trimmed = s.Trim(ParseUtils.Asterisk);
                 //Contains query
                 if (s.StartsWith("*") && s.EndsWith("*"))
                 {

--- a/Plugins/RemoteReader/RemoteReaderPlugin.cs
+++ b/Plugins/RemoteReader/RemoteReaderPlugin.cs
@@ -209,7 +209,7 @@ namespace ImageResizer.Plugins.RemoteReader {
                 }
                 args.RemoteUrl = PathUtils.FromBase64UToString(data);
             } else {
-                args.RemoteUrl = "http://" + ReplaceInLeadingSegment(virtualPath.Substring(remotePrefix.Length).TrimStart('/', '\\'), "_", ".");
+                args.RemoteUrl = "http://" + ReplaceInLeadingSegment(virtualPath.Substring(remotePrefix.Length).TrimStart(ParseUtils.Slashes), "_", ".");
                 args.RemoteUrl = Uri.EscapeUriString(args.RemoteUrl);
             }
             if (!Uri.IsWellFormedUriString(args.RemoteUrl, UriKind.Absolute))

--- a/Plugins/S3Reader/S3File.cs
+++ b/Plugins/S3Reader/S3File.cs
@@ -13,6 +13,7 @@ using ImageResizer.Resizing;
 using Amazon.S3.Model;
 using ImageResizer.ExtensionMethods;
 using Amazon.S3;
+using ImageResizer.Util;
 
 namespace ImageResizer.Plugins.S3Reader {
 
@@ -83,13 +84,13 @@ namespace ImageResizer.Plugins.S3Reader {
             String path = VirtualPath.Substring(provider.VirtualFilesystemPrefix.Length);
 
             //strip leading slashes
-            path = path.TrimStart(new char[] { '/', '\\' });
+            path = path.TrimStart(ParseUtils.Slashes);
 
             //Now execute filter!
             path = provider.FilterPath(path);
 
             //strip leading slashes again
-            path = path.TrimStart(new char[] { '/', '\\' });
+            path = path.TrimStart(ParseUtils.Slashes);
 
 
             int keyStartsAt = path.IndexOf('/');
@@ -97,7 +98,7 @@ namespace ImageResizer.Plugins.S3Reader {
             //Get bucket
             bucket = path.Substring(0, keyStartsAt);
             //Get key
-            key = path.Substring(keyStartsAt + 1).TrimStart(new char[] { '/', '\\' });
+            key = path.Substring(keyStartsAt + 1).TrimStart(ParseUtils.Slashes);
         }
 
 
@@ -115,7 +116,6 @@ namespace ImageResizer.Plugins.S3Reader {
                 else if ( se.StatusCode == System.Net.HttpStatusCode.Forbidden || "AccessDenied".Equals(se.ErrorCode, StringComparison.OrdinalIgnoreCase)) throw new FileNotFoundException("Amazon S3 access denied - file may not exist", se);
                 else throw;
             }
-            return null;
         }
 
         public DateTime ModifiedDateUTC {

--- a/Plugins/S3Reader/S3PathEventArgs.cs
+++ b/Plugins/S3Reader/S3PathEventArgs.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Web;
 using System.IO;
 using ImageResizer.Resizing;
+using ImageResizer.Util;
 
 namespace ImageResizer.Plugins.S3Reader {
     /// <summary>
@@ -63,8 +64,8 @@ namespace ImageResizer.Plugins.S3Reader {
         /// </summary>
         /// <param name="bucket"></param>
         public void PrefixBucket(String bucket) {
-            bucket = bucket.Trim('\\', '/');
-            Path = bucket + "/" + Path.TrimStart('/');
+            bucket = bucket.Trim(ParseUtils.Slashes);
+            Path = bucket + "/" + Path.TrimStart(ParseUtils.ForwardSlash);
         }
         /// <summary>
         /// Parses the bucket from Path
@@ -73,7 +74,7 @@ namespace ImageResizer.Plugins.S3Reader {
         public string Bucket {
             get {
                 //strip leading slashes
-                string path = Path.TrimStart(new char[] { '/', '\\' });
+                string path = Path.TrimStart(ParseUtils.Slashes);
 
                 int keyStartsAt = path.IndexOf('/');
                 if (keyStartsAt < 0) return path; //No key present
@@ -88,15 +89,14 @@ namespace ImageResizer.Plugins.S3Reader {
         public string Key {
             get {
                 //strip leading slashes
-                string path = Path.TrimStart(new char[] { '/', '\\' });
+                string path = Path.TrimStart(ParseUtils.Slashes);
 
                 int keyStartsAt = path.IndexOf('/');
                 if (keyStartsAt < 0) return null; //no key
 
                 //Get key
-                return path.Substring(keyStartsAt + 1).TrimStart(new char[] { '/', '\\' });
+                return path.Substring(keyStartsAt + 1).TrimStart(ParseUtils.Slashes);
             }
         }
     }
-
 }

--- a/Plugins/S3Reader/S3Reader.cs
+++ b/Plugins/S3Reader/S3Reader.cs
@@ -110,7 +110,7 @@ namespace ImageResizer.Plugins.S3Reader {
             if (string.IsNullOrEmpty(vpath)) vpath = "~/s3/";
 
             string[] bucketArray = null;
-            if (!string.IsNullOrEmpty(buckets)) bucketArray = buckets.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+            if (!string.IsNullOrEmpty(buckets)) bucketArray = buckets.Split(ParseUtils.Comma, StringSplitOptions.RemoveEmptyEntries);
             else c.configurationSectionIssues.AcceptIssue(new Issue("S3Reader", "S3Reader cannot function without a list of permitted bucket names.",
                 "Please specify a comma-delimited list of buckets in the <add name='S3Reader' buckets='bucketa,bucketb' /> element.",
                  IssueSeverity.ConfigurationError));

--- a/Plugins/S3Reader2/S3File.cs
+++ b/Plugins/S3Reader2/S3File.cs
@@ -13,6 +13,7 @@ using ImageResizer.Resizing;
 using Amazon.S3.Model;
 using ImageResizer.ExtensionMethods;
 using Amazon.S3;
+using ImageResizer.Util;
 
 namespace ImageResizer.Plugins.S3Reader2 {
 
@@ -83,13 +84,13 @@ namespace ImageResizer.Plugins.S3Reader2 {
             String path = VirtualPath.Substring(provider.VirtualFilesystemPrefix.Length);
 
             //strip leading slashes
-            path = path.TrimStart(new char[] { '/', '\\' });
+            path = path.TrimStart(ParseUtils.Slashes);
 
             //Now execute filter!
             path = provider.FilterPath(path);
 
             //strip leading slashes again
-            path = path.TrimStart(new char[] { '/', '\\' });
+            path = path.TrimStart(ParseUtils.Slashes);
 
 
             int keyStartsAt = path.IndexOf('/');
@@ -97,7 +98,7 @@ namespace ImageResizer.Plugins.S3Reader2 {
             //Get bucket
             bucket = path.Substring(0, keyStartsAt);
             //Get key
-            key = path.Substring(keyStartsAt + 1).TrimStart(new char[] { '/', '\\' });
+            key = path.Substring(keyStartsAt + 1).TrimStart(ParseUtils.Slashes);
         }
 
 
@@ -115,7 +116,6 @@ namespace ImageResizer.Plugins.S3Reader2 {
                 else if ( se.StatusCode == System.Net.HttpStatusCode.Forbidden || "AccessDenied".Equals(se.ErrorCode, StringComparison.OrdinalIgnoreCase)) throw new FileNotFoundException("Amazon S3 access denied - file may not exist", se);
                 else throw;
             }
-            return null;
         }
 
         public DateTime ModifiedDateUTC {

--- a/Plugins/S3Reader2/S3PathEventArgs.cs
+++ b/Plugins/S3Reader2/S3PathEventArgs.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Web;
 using System.IO;
 using ImageResizer.Resizing;
+using ImageResizer.Util;
 
 namespace ImageResizer.Plugins.S3Reader2 {
     /// <summary>
@@ -63,8 +64,8 @@ namespace ImageResizer.Plugins.S3Reader2 {
         /// </summary>
         /// <param name="bucket"></param>
         public void PrefixBucket(String bucket) {
-            bucket = bucket.Trim('\\', '/');
-            Path = bucket + "/" + Path.TrimStart('/');
+            bucket = bucket.Trim(ParseUtils.Slashes);
+            Path = bucket + "/" + Path.TrimStart(ParseUtils.ForwardSlash);
         }
         /// <summary>
         /// Parses the bucket from Path
@@ -73,7 +74,7 @@ namespace ImageResizer.Plugins.S3Reader2 {
         public string Bucket {
             get {
                 //strip leading slashes
-                string path = Path.TrimStart(new char[] { '/', '\\' });
+                string path = Path.TrimStart(ParseUtils.Slashes);
 
                 int keyStartsAt = path.IndexOf('/');
                 if (keyStartsAt < 0) return path; //No key present
@@ -88,13 +89,13 @@ namespace ImageResizer.Plugins.S3Reader2 {
         public string Key {
             get {
                 //strip leading slashes
-                string path = Path.TrimStart(new char[] { '/', '\\' });
+                string path = Path.TrimStart(ParseUtils.Slashes);
 
                 int keyStartsAt = path.IndexOf('/');
                 if (keyStartsAt < 0) return null; //no key
 
                 //Get key
-                return path.Substring(keyStartsAt + 1).TrimStart(new char[] { '/', '\\' });
+                return path.Substring(keyStartsAt + 1).TrimStart(ParseUtils.Slashes);
             }
         }
     }

--- a/Plugins/S3Reader2/S3Reader.cs
+++ b/Plugins/S3Reader2/S3Reader.cs
@@ -118,7 +118,7 @@ namespace ImageResizer.Plugins.S3Reader2 {
             if (string.IsNullOrEmpty(vpath)) vpath = "~/s3/";
 
             string[] bucketArray = null;
-            if (!string.IsNullOrEmpty(buckets)) bucketArray = buckets.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+            if (!string.IsNullOrEmpty(buckets)) bucketArray = buckets.Split(ParseUtils.Comma, StringSplitOptions.RemoveEmptyEntries);
             else c.configurationSectionIssues.AcceptIssue(new Issue("S3Reader", "S3Reader cannot function without a list of permitted bucket names.",
                 "Please specify a comma-delimited list of buckets in the <add name='S3Reader' buckets='bucketa,bucketb' /> element.",
                  IssueSeverity.ConfigurationError));

--- a/Plugins/SeamCarving/SeamCarvingPlugin.cs
+++ b/Plugins/SeamCarving/SeamCarvingPlugin.cs
@@ -48,7 +48,7 @@ namespace ImageResizer.Plugins.SeamCarving {
 
             //Parse carve data bitmap
             if (!string.IsNullOrEmpty(s.settings["carve.data"])) {
-                string[] parts = s.settings["carve.data"].Split('|');
+                string[] parts = s.settings["carve.data"].Split(ParseUtils.VBar);
                 //Parse block count and string
                 var block_count = int.Parse(parts[0]);
                 var carveString = new LzwDecoder("012").Decode(PathUtils.FromBase64UToBytes(parts[1]));

--- a/Plugins/Security/Encrypted.cs
+++ b/Plugins/Security/Encrypted.cs
@@ -81,13 +81,13 @@ namespace ImageResizer.Plugins.Encrypted {
         public string EncryptPathAndQuery(string virtualPathAndQuery) {
             
             if (virtualPathAndQuery.StartsWith(PathUtils.AppVirtualPath)){
-                virtualPathAndQuery = "~/" + virtualPathAndQuery.Substring(PathUtils.AppVirtualPath.Length).TrimStart('/');
+                virtualPathAndQuery = "~/" + virtualPathAndQuery.Substring(PathUtils.AppVirtualPath.Length).TrimStart(ParseUtils.ForwardSlash);
             }
 
             if (!virtualPathAndQuery.StartsWith("~/")) throw new ArgumentException();
 
 
-            return VirtualPrefix.TrimEnd('/') + '/' + Encrypt(virtualPathAndQuery.Substring(1).TrimStart('/')) + ".ashx";
+            return VirtualPrefix.TrimEnd(ParseUtils.ForwardSlash) + '/' + Encrypt(virtualPathAndQuery.Substring(1).TrimStart(ParseUtils.ForwardSlash)) + ".ashx";
 
         }
 
@@ -103,7 +103,7 @@ namespace ImageResizer.Plugins.Encrypted {
             Stopwatch sw = new Stopwatch();
             sw.Start();
             string both = c.Pipeline.PreRewritePath.Substring(VirtualPrefix.Length); //Strip prefix
-            string[] parts = both.Split('/'); //Split
+            string[] parts = both.Split(ParseUtils.ForwardSlash); //Split
 
             if (parts.Length != 2) return; //There must be exactly two parts
 

--- a/Plugins/SqlReader/SqlReader.cs
+++ b/Plugins/SqlReader/SqlReader.cs
@@ -13,6 +13,7 @@ using System.Collections.Specialized;
 using ImageResizer.Configuration.Issues;
 using System.Security;
 using ImageResizer.Configuration.Xml;
+using ImageResizer.Util;
 namespace ImageResizer.Plugins.SqlReader
 {
     /// <summary>
@@ -277,7 +278,7 @@ namespace ImageResizer.Plugins.SqlReader
             if (!checkPath.StartsWith(s.VirtualPathPrefix, StringComparison.OrdinalIgnoreCase)) return null;
             string id = checkPath.Substring(s.VirtualPathPrefix.Length); //Strip prefix
             //Strip slashes at beginning 
-            id = id.TrimStart(new char[] { '/', '\\' });
+            id = id.TrimStart(ParseUtils.Slashes);
             //Strip extension if not a string 
             if (!IsStringKey || s.StripFileExtension) {
                 int length = id.LastIndexOf('.');

--- a/Plugins/TinyCache/TinyCachePlugin.cs
+++ b/Plugins/TinyCache/TinyCachePlugin.cs
@@ -21,7 +21,7 @@ namespace ImageResizer.Plugins.TinyCache {
         }
 
 
-        protected string virtualCacheFile = HostingEnvironment.ApplicationVirtualPath.TrimEnd('/') + "/App_Data/tiny_cache.cache";
+        protected string virtualCacheFile = HostingEnvironment.ApplicationVirtualPath.TrimEnd(ParseUtils.ForwardSlash) + "/App_Data/tiny_cache.cache";
         /// <summary>
         /// Sets the location of the cache file
         /// </summary>

--- a/Plugins/UploadHelper/ImageUploadHelper.cs
+++ b/Plugins/UploadHelper/ImageUploadHelper.cs
@@ -29,7 +29,7 @@ namespace ImageResizer
         /// <returns></returns>
         public string GetExtension(string path)
         {
-            int lastDot = path.LastIndexOfAny(new char[] { '.', '/', ' ', '\\', '?', '&', ':' });
+            int lastDot = path.LastIndexOfAny(ParseUtils.PathParts);
             if (lastDot > -1 && path[lastDot] == '.') return path.Substring(lastDot + 1);
             else return null;
         }

--- a/Plugins/Watermark/LegacyWatermarkFeatures.cs
+++ b/Plugins/Watermark/LegacyWatermarkFeatures.cs
@@ -196,7 +196,7 @@ namespace ImageResizer.Plugins.Watermark {
             if (string.IsNullOrEmpty(watermark) || watermarkDir == null) return false;
 
             if (watermark.IndexOfAny(System.IO.Path.GetInvalidFileNameChars()) > -1 ||
-                watermark.IndexOfAny(new char[] { '\\', '/' }) > -1)
+                watermark.IndexOfAny(ParseUtils.Slashes) > -1)
                 return false;
 
             //Combine the directory with the base dir

--- a/Plugins/Watermark/Watermark.cs
+++ b/Plugins/Watermark/Watermark.cs
@@ -192,7 +192,7 @@ namespace ImageResizer.Plugins.Watermark
         private ImageLayer CreateLayerFromOtherImages(string watermarkPath)
         {
             if (watermarkPath.IndexOfAny(System.IO.Path.GetInvalidFileNameChars()) > -1 ||
-                watermarkPath.IndexOfAny(new char[] { '\\', '/' }) > -1) {
+                watermarkPath.IndexOfAny(ParseUtils.Slashes) > -1) {
                 throw new ArgumentException("Watermark value contained invalid file name characters: " + watermarkPath);
             }
 
@@ -285,7 +285,7 @@ namespace ImageResizer.Plugins.Watermark
             watermark = nvc["watermark"];
             if (string.IsNullOrEmpty(watermark)) return null;
 
-            string[] parts = watermark.Split(new string[] { "," }, StringSplitOptions.RemoveEmptyEntries);
+            string[] parts = watermark.Split(ParseUtils.Comma, StringSplitOptions.RemoveEmptyEntries);
             return parts;
         }
     }

--- a/Plugins/Wic/WicDecoder.cs
+++ b/Plugins/Wic/WicDecoder.cs
@@ -33,7 +33,7 @@ namespace ImageResizer.Plugins.WicDecoder {
             return true;
         }
         public IEnumerable<string> GetSupportedFileExtensions() {
-            return new string[] { }; //Same as default
+            return ParseUtils.EmptyStringArray; //Same as default
         }
 
         public override System.Drawing.Bitmap DecodeStream(System.IO.Stream s, ResizeSettings settings, string optionalPath) {

--- a/Plugins/Wpf/WpfBuilder.cs
+++ b/Plugins/Wpf/WpfBuilder.cs
@@ -205,7 +205,7 @@ namespace ImageResizer.Plugins.WpfBuilder
 
         public IEnumerable<string> GetSupportedFileExtensions()
         {
-            return new string[] { };
+            return ParseUtils.EmptyStringArray;
         }
 
         #endregion

--- a/Samples/CustomOverlayPlugin/CachedOverlayProvider.cs
+++ b/Samples/CustomOverlayPlugin/CachedOverlayProvider.cs
@@ -146,8 +146,8 @@ namespace ImageResizer.Plugins.CustomOverlay {
                     //Build overlay path
                     Overlay o = new Overlay();
                     StringBuilder p = new StringBuilder();
-                    //p.AppendFormat("{4}/{0}_{1}_{2}_{3}.png", r.GetString(0), r.GetString(1), r.GetBoolean(2) ? "dark" : "light", r.GetString(3), this.OverlayBasePath.TrimEnd('/'));
-                    p.AppendFormat("{4}/{0}/LogoImages/{0}_{1}_{2}_{3}.png", r.GetString(0), r.GetString(1), r.GetBoolean(2) ? "dark" : "light", r.GetString(3), this.OverlayBasePath.TrimEnd('/'));
+                    //p.AppendFormat("{4}/{0}_{1}_{2}_{3}.png", r.GetString(0), r.GetString(1), r.GetBoolean(2) ? "dark" : "light", r.GetString(3), this.OverlayBasePath.TrimEnd(ParseUtils.ForwardSlash));
+                    p.AppendFormat("{4}/{0}/LogoImages/{0}_{1}_{2}_{3}.png", r.GetString(0), r.GetString(1), r.GetBoolean(2) ? "dark" : "light", r.GetString(3), this.OverlayBasePath.TrimEnd(ParseUtils.ForwardSlash));
                     p.Replace(" ", "");
                     o.OverlayPath = p.ToString();
 

--- a/Samples/CustomOverlayPlugin/EtagsPlugin.cs
+++ b/Samples/CustomOverlayPlugin/EtagsPlugin.cs
@@ -4,6 +4,7 @@ using System.Text;
 using ImageResizer.Configuration;
 using ImageResizer.Caching;
 using System.Web;
+using ImageResizer.Util;
 
 namespace ImageResizer.Plugins.Etags {
     public class EtagsPlugin:IPlugin, ICache {
@@ -48,7 +49,7 @@ namespace ImageResizer.Plugins.Etags {
             string ifNoneMatch = current.Request.Headers["If-None-Match"];
             if (string.IsNullOrEmpty(ifNoneMatch)) return null;
             if (ifNoneMatch.StartsWith("W/"))ifNoneMatch = ifNoneMatch.Substring(2);
-            ifNoneMatch = ifNoneMatch.Trim('"');
+            ifNoneMatch = ifNoneMatch.Trim(ParseUtils.DoubleQuote);
             return string.IsNullOrEmpty(ifNoneMatch) ? null : ifNoneMatch;
         }
 

--- a/Samples/CustomOverlayPlugin/QuerystringOverlayProvider.cs
+++ b/Samples/CustomOverlayPlugin/QuerystringOverlayProvider.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Collections.Specialized;
 using System.Drawing;
+using ImageResizer.Util;
 
 namespace ImageResizer.Plugins.CustomOverlay {
     /// <summary>
@@ -32,7 +33,7 @@ namespace ImageResizer.Plugins.CustomOverlay {
 
             
 
-            string[] coords = poly.Split(',');
+            string[] coords = poly.Split(ParseUtils.Comma);
             
             if (coords.Length != 8 && coords.Length != 4) return null; //Not valid coords
 
@@ -55,7 +56,7 @@ namespace ImageResizer.Plugins.CustomOverlay {
 
 
             //Build path
-            o.OverlayPath = OverlayFolder.TrimEnd('/') + '/' + Util.PathUtils.RemoveNonMatchingChars(image, ValidImageChars);
+            o.OverlayPath = OverlayFolder.TrimEnd(ParseUtils.ForwardSlash) + '/' + Util.PathUtils.RemoveNonMatchingChars(image, ValidImageChars);
 
             return new Overlay[] { o };
         }

--- a/Samples/ImageStudio/Default.aspx.cs
+++ b/Samples/ImageStudio/Default.aspx.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Linq;
 using System.Web;
 using System.Web.UI;
@@ -8,7 +9,6 @@ using System.Text;
 using System.IO;
 using System.Web.Hosting;
 using ImageResizer.Util;
-using System.Collections.Specialized;
 
 namespace ImageStudio {
     public partial class _Default : System.Web.UI.Page {
@@ -18,7 +18,7 @@ namespace ImageStudio {
             physicalBasePath = Path.Combine(HostingEnvironment.ApplicationPhysicalPath,physicalBasePath);
             string[] exts = extensions.Split(new char[]{'|',';',','}, StringSplitOptions.RemoveEmptyEntries);
             foreach (string dir in subdirs) {
-                var sdir = dir.Trim('/','\\');
+                var sdir = dir.Trim(ParseUtils.Slashes);
                 string full = Path.GetFullPath(Path.Combine(physicalBasePath, sdir.Replace('/', '\\')));
                 if (System.IO.Directory.Exists(full)) {
                     foreach(string e in exts){
@@ -26,7 +26,7 @@ namespace ImageStudio {
                         foreach(string physicalFile in physicals){
                             string name = System.IO.Path.GetFileName(physicalFile);
                             if (name.StartsWith(".")) continue;
-                            string url = ResolveUrl(basePath.TrimEnd('/') + '/' + sdir + '/' + System.IO.Path.GetFileName(name));
+                            string url = ResolveUrl(basePath.TrimEnd(ParseUtils.ForwardSlash) + '/' + sdir + '/' + System.IO.Path.GetFileName(name));
                             paths.Add(url);
                         }
                     }

--- a/Samples/MvcSample/Global.asax.cs
+++ b/Samples/MvcSample/Global.asax.cs
@@ -34,7 +34,7 @@ namespace MvcSample {
 
         static void Pipeline_Rewrite(IHttpModule sender, HttpContext context, IUrlEventArgs e) {
             if (e.VirtualPath.StartsWith(PathUtils.ResolveAppRelative("~/photos/"), StringComparison.OrdinalIgnoreCase)) 
-                e.VirtualPath = PathUtils.ResolveAppRelative("~/App_Data/") + e.VirtualPath.Substring(PathUtils.AppVirtualPath.Length).TrimStart('/');
+                e.VirtualPath = PathUtils.ResolveAppRelative("~/App_Data/") + e.VirtualPath.Substring(PathUtils.AppVirtualPath.Length).TrimStart(ParseUtils.ForwardSlash);
         }
 
         protected void Application_Start() {

--- a/Samples/PluginTestingApp/Misc/WhitespaceTrimmerTest.aspx.cs
+++ b/Samples/PluginTestingApp/Misc/WhitespaceTrimmerTest.aspx.cs
@@ -7,12 +7,13 @@ using System.Web.UI.WebControls;
 using System.IO;
 using System.Text;
 using System.Web.Hosting;
+using ImageResizer.Util;
 
 namespace ComplexWebApplication {
     public partial class WhitespaceTrimmerTest : System.Web.UI.Page {
         protected void Page_Load(object sender, EventArgs e) {
-            
-            string dir = Path.Combine(Path.Combine(Path.GetDirectoryName(HostingEnvironment.ApplicationPhysicalPath.TrimEnd('/','\\')),  "Images"), "private");
+
+            string dir = Path.Combine(Path.Combine(Path.GetDirectoryName(HostingEnvironment.ApplicationPhysicalPath.TrimEnd(ParseUtils.Slashes)), "Images"), "private");
             if (!Directory.Exists(dir)) return;
             string[] files = Directory.GetFiles(dir,"*.jpg");
             StringBuilder sb = new StringBuilder();

--- a/Samples/SqlReaderSample/Upload.aspx.cs
+++ b/Samples/SqlReaderSample/Upload.aspx.cs
@@ -70,7 +70,7 @@ namespace DatabaseSampleCSharp {
                     }
                 } else {
                     //It's not an image - upload as-is.
-                    lastUpload = StoreFile(StreamExtensions.CopyToBytes(file.InputStream), PathUtils.GetExtension(file.FileName).TrimStart('.'), file.FileName);
+                    lastUpload = StoreFile(StreamExtensions.CopyToBytes(file.InputStream), PathUtils.GetExtension(file.FileName).TrimStart(ParseUtils.Period), file.FileName);
 
                 }
             }


### PR DESCRIPTION
All calls for Trim(params char[]), TrimStart(params char[]),
TrimEnd(params char[]), IndexOfAny(char []), LastIndexOfAny(char [])
and Split(params char[]) now use static readonly constants in
ParseUtils so we don't keep newing up char arrays.
Use StringBuilder instead of string concatenation.
Used StringBuilder.Length mutator to trim trailing characters.
Add EmptyStringArray to use in place of new string[0] and new string[] {}
BUG FIX: FacesPlugin was not using Invariant culture when building the
face strings.
Killed two dead-code return null lines.