### PR TITLE
Added named profile and EC2 Instance Profile support

### DIFF
--- a/Plugins/S3Reader2/S3Reader.cs
+++ b/Plugins/S3Reader2/S3Reader.cs
@@ -40,7 +40,7 @@ namespace ImageResizer.Plugins.S3Reader2 {
             if (!string.IsNullOrEmpty(args["accessKeyId"]) && !string.IsNullOrEmpty(args["secretAccessKey"])) {
                 S3Client = new AmazonS3Client(args["accessKeyId"], args["secretAccessKey"], s3config);
             } else {
-                S3Client = new AmazonS3Client(null, s3config);
+                S3Client = new AmazonS3Client(s3config);
             }
         }
 


### PR DESCRIPTION
Added support for AmazonS3Client to fallback on named profiles (SDK store) or EC2 Instance Profiles, per the AWS [docs](http://docs.aws.amazon.com/sdkfornet1/latest/apidocs/html/T_Amazon_S3_AmazonS3Client.htm).  This will allow users to remove the AWS AccessKey/SecretKey values form their web.config, which is the recommended method for [configuring AWS credentials](http://docs.aws.amazon.com/AWSSdkDocsNET/latest/V3/DeveloperGuide/net-dg-config-creds.html).
