### PR TITLE
Added argument to use AWS Profile if credentials are not set and prof…

### DIFF
--- a/Plugins/S3Reader2/S3Reader.cs
+++ b/Plugins/S3Reader2/S3Reader.cs
@@ -39,7 +39,12 @@ namespace ImageResizer.Plugins.S3Reader2 {
 
             if (!string.IsNullOrEmpty(args["accessKeyId"]) && !string.IsNullOrEmpty(args["secretAccessKey"])) {
                 S3Client = new AmazonS3Client(args["accessKeyId"], args["secretAccessKey"], s3config);
-            } else {
+            } else if (!string.IsNullOrEmpty(args["useProfile"]) && args["useProfile"] == "true")
+            {
+                S3Client = new AmazonS3Client(s3config);
+            }
+            else
+            {
                 S3Client = new AmazonS3Client(null, s3config);
             }
         }


### PR DESCRIPTION
…ile flag is set to true

Added support for AmazonS3Client to use named profiles (SDK store) or EC2 Instance Profiles, per the AWS docs. This will allow users to remove the AWS AccessKey/SecretKey values form their web.config, which is the recommended method for configuring AWS credentials.
