### PR TITLE
Removed the spawning of a new thread when running ImageBuilder.Build()

### DIFF
--- a/Core/AsyncInterceptModule.cs
+++ b/Core/AsyncInterceptModule.cs
@@ -217,7 +217,7 @@ namespace ImageResizer
                         j.Source = inBuffer;
                         
 
-                        await Task.Run(delegate() { conf.GetImageBuilder().Build(j); });
+                        conf.GetImageBuilder().Build(j);
                         outBuffer.Seek(0, SeekOrigin.Begin);
                         await outBuffer.CopyToAsync(stream);
                     }

--- a/Core/AsyncInterceptModule.cs
+++ b/Core/AsyncInterceptModule.cs
@@ -22,6 +22,7 @@ using System.Web.Hosting;
 using System.Web.Security;
 using ImageResizer.ExtensionMethods;
 using System.Globalization;
+﻿using System.Threading;
 
 namespace ImageResizer
 {
@@ -216,8 +217,10 @@ namespace ImageResizer
 
                         j.Source = inBuffer;
                         
-
-                        conf.GetImageBuilder().Build(j);
+                        await Task.Factory.StartNew(() => conf.GetImageBuilder().Build(j), 
+                                                    CancellationToken.None,
+                                                    TaskCreationOptions.None,
+                                                    TaskScheduler.FromCurrentSynchronizationContext());
                         outBuffer.Seek(0, SeekOrigin.Begin);
                         await outBuffer.CopyToAsync(stream);
                     }


### PR DESCRIPTION
We don't acutally need to run this inside a different thread
