### PR TITLE
Added PreHandleImage EventHandler for the AsyncInterceptModule

### DIFF
--- a/Core/AsyncInterceptModule.cs
+++ b/Core/AsyncInterceptModule.cs
@@ -250,7 +250,7 @@ namespace ImageResizer
             context.Items[conf.ResponseArgsKey] = e; //store in context items
 
             //Fire events (for client-side caching plugins)
-            //conf.FirePreHandleImage(this, context, e);
+            conf.FirePreHandleImageAsync(this, context, e);
 
             //Pass the rest of the work off to the caching module. It will handle rewriting/redirecting and everything. 
             //We handle request headers based on what is found in context.Items

--- a/Core/AsyncInterceptModule.cs
+++ b/Core/AsyncInterceptModule.cs
@@ -217,7 +217,7 @@ namespace ImageResizer
                         j.Source = inBuffer;
                         
 
-                        await Task.Run(delegate() { conf.GetImageBuilder().Build(j); });
+                        conf.GetImageBuilder().Build(j);
                         outBuffer.Seek(0, SeekOrigin.Begin);
                         await outBuffer.CopyToAsync(stream);
                     }

--- a/Core/AsyncInterceptModule.cs
+++ b/Core/AsyncInterceptModule.cs
@@ -22,6 +22,7 @@ using System.Web.Hosting;
 using System.Web.Security;
 using ImageResizer.ExtensionMethods;
 using System.Globalization;
+﻿using System.Threading;
 
 namespace ImageResizer
 {
@@ -216,8 +217,10 @@ namespace ImageResizer
 
                         j.Source = inBuffer;
                         
-
-                        conf.GetImageBuilder().Build(j);
+                        await Task.Factory.StartNew(() => conf.GetImageBuilder().Build(j), 
+                                                    CancellationToken.None,
+                                                    TaskCreationOptions.None,
+                                                    TaskScheduler.FromCurrentSynchronizationContext());
                         outBuffer.Seek(0, SeekOrigin.Begin);
                         await outBuffer.CopyToAsync(stream);
                     }

--- a/Core/Configuration/IPipelineConfig.cs
+++ b/Core/Configuration/IPipelineConfig.cs
@@ -24,6 +24,7 @@ namespace ImageResizer.Configuration {
     public delegate void UrlEventHandler(IHttpModule sender, HttpContext context, IUrlEventArgs e);
     public delegate void UrlAuthorizationEventHandler(IHttpModule sender, HttpContext context, IUrlAuthorizationEventArgs e);
     public delegate void PreHandleImageEventHandler(IHttpModule sender, HttpContext context, IResponseArgs e);
+    public delegate void PreHandleImageAsyncEventHandler(IHttpModule sender, HttpContext context, IAsyncResponsePlan e);
     public delegate void CacheSelectionHandler(object sender, ICacheSelectionEventArgs e);
 
 
@@ -159,10 +160,10 @@ namespace ImageResizer.Configuration {
 
         void FirePreHandleImage(IHttpModule sender, System.Web.HttpContext context, IResponseArgs e);
 
+        void FirePreHandleImageAsync(IHttpModule sender, System.Web.HttpContext context, IAsyncResponsePlan e);
 
         void FireImageMissing(IHttpModule sender, System.Web.HttpContext context, IUrlEventArgs urlEventArgs);
-
-
+        
         NameValueCollection ModifiedQueryString { get; set; }
 
         bool IsAppDomainUnrestricted();

--- a/Core/Configuration/PipelineConfig.cs
+++ b/Core/Configuration/PipelineConfig.cs
@@ -471,10 +471,16 @@ namespace ImageResizer.Configuration {
         public event UrlEventHandler ImageMissing;
 
         /// <summary>
-        /// Fired immediately before the image request is sent off to the caching system for proccessing.
+        /// (Sync Intercept Module only) Fired immediately before the image request is sent off to the caching system for proccessing.
         /// Allows modification of response headers, caching arguments, and callbacks.
         /// </summary>
         public event PreHandleImageEventHandler PreHandleImage;
+
+        /// <summary>
+        /// (ASYNC Intercept Module only) Fired immediately before the image request is sent off to the caching system for proccessing.
+        /// Allows modification of response headers, caching arguments, and callbacks.
+        /// </summary>
+        public event PreHandleImageAsyncEventHandler PreHandleImageAsync;
 
         public event CacheSelectionHandler SelectCachingSystem;
 
@@ -528,6 +534,12 @@ namespace ImageResizer.Configuration {
 
         public void FireAuthorizeImage(System.Web.IHttpModule sender, System.Web.HttpContext context, IUrlAuthorizationEventArgs e) {
             if (AuthorizeImage != null) AuthorizeImage(sender, context, e);
+        }
+
+        public void FirePreHandleImageAsync(IHttpModule sender, HttpContext context, IAsyncResponsePlan e)
+        {
+            System.Threading.Interlocked.Increment(ref processedCount);
+            if (PreHandleImageAsync != null) PreHandleImageAsync(sender, context, e);
         }
 
         public void FireImageMissing(System.Web.IHttpModule sender, System.Web.HttpContext context, IUrlEventArgs e) {


### PR DESCRIPTION
Needed to duplicate the event and delegate because the Async pipeline uses different classes.
