### PR TITLE
Set something in the UserAgent header to avoid errors from some servers

### DIFF
--- a/Plugins/RemoteReader/RemoteReaderPlugin.cs
+++ b/Plugins/RemoteReader/RemoteReaderPlugin.cs
@@ -331,6 +331,7 @@ namespace ImageResizer.Plugins.RemoteReader {
             try {
                 HttpWebRequest request = (HttpWebRequest)WebRequest.Create(uri);
                 request.Timeout = 15000; //Default to 15 seconds. Browser timeout is usually 30.
+                request.UserAgent = "ImageResizer";
                 
                 //This is IDisposable, but only disposes the stream we are returning. So we can't dispose it, and don't need to
                 response = request.GetResponse() as HttpWebResponse;


### PR DESCRIPTION
I have found a few servers are returning 403 errors, but when I include a UserAgent in the request header, it works.  I added the following at line 334 of the plugin:
request.UserAgent = "ImageResizer";

Here is a sample image where the server is returning 403's if a UserAgent is not included.  
http://www.backcountry.com/images/items/900/JUL/JUL0110/LIL.jpg

-Ed
