### PR TITLE
Prevent the GC from collecting objects during Ghostscript execution

### DIFF
--- a/Contrib/PdfRenderer/PdfRenderer/Ghostscript/GhostscriptEngine.cs
+++ b/Contrib/PdfRenderer/PdfRenderer/Ghostscript/GhostscriptEngine.cs
@@ -118,6 +118,11 @@ namespace ImageResizer.Plugins.PdfRenderer.Ghostscript
                 // If Ghostscript has been initialised, you must call gsapi_exit before gsapi_delete_instance.
                 GhostscriptNativeMethods.DeleteInstance(instance);
             }
+            
+            //Prevent the GC from collecting objects during Ghostscript execution
+            GC.KeepAlive(outputHandler);
+            GC.KeepAlive(errorHandler);
+            GC.KeepAlive(inputHandler);
 
             // Check for errors. Zero and e_Quit(-101) are not errors.
             string output = outputBuilder.ToString();


### PR DESCRIPTION
If GC will collect objects between 
`GhostscriptNativeMethods.SetMessageHandlers(instance, inputHandler, outputHandler, errorHandler);`
and 
`result = GhostscriptNativeMethods.InitializeWithArguments(instance, arguments.Length, arguments);`
it collects "outputHandler", "errorHandler", "inputHandler" delegates and Ghostscript will fail.
