### PR TITLE
Update RemoteReaderPlugin.cs

### DIFF
--- a/Plugins/RemoteReader/RemoteReaderPlugin.cs
+++ b/Plugins/RemoteReader/RemoteReaderPlugin.cs
@@ -336,6 +336,7 @@ namespace ImageResizer.Plugins.RemoteReader {
             HttpWebResponse response = null;
             try {
                 HttpWebRequest request = (HttpWebRequest)WebRequest.Create(uri);
+                request.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip;
                 request.Timeout = 15000; //Default to 15 seconds. Browser timeout is usually 30.
                 request.UserAgent = "ImageResizer";
                 


### PR DESCRIPTION
I had to enabled the AutomaticDecompression of http response because of the exception "Parameter not valid.".
It was caused because the remote link was was returning a gzipped image, so the Bitmap constructor wasn't able to run.

