### PR TITLE
Unify async and synch GetUriStream methods

### DIFF
--- a/Plugins/RemoteReader/RemoteReaderPlugin.cs
+++ b/Plugins/RemoteReader/RemoteReaderPlugin.cs
@@ -331,37 +331,13 @@ namespace ImageResizer.Plugins.RemoteReader {
         /// <param name="maxRedirects"></param>
         /// <returns></returns>
         public Stream GetUriStream(Uri uri, int maxRedirects = -1) {
-            if (maxRedirects == -1) maxRedirects = AllowedRedirects;
-
             HttpWebResponse response = null;
             try {
-                HttpWebRequest request = (HttpWebRequest)WebRequest.Create(uri);
-                request.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip;
-                request.Timeout = 15000; //Default to 15 seconds. Browser timeout is usually 30.
-                request.UserAgent = "ImageResizer";
-                
                 //This is IDisposable, but only disposes the stream we are returning. So we can't dispose it, and don't need to
-                response = request.GetResponse() as HttpWebResponse;
+                response = CreateWebRequest(uri, maxRedirects).GetResponse() as HttpWebResponse;
                 return response.GetResponseStream();
             } catch (WebException e) {
-                var resp = e.Response as HttpWebResponse;
-
-                if (e.Status == WebExceptionStatus.ProtocolError && resp != null) {
-                    if (resp.StatusCode == HttpStatusCode.NotFound) throw new FileNotFoundException("404 error: \"" + uri.ToString() + "\" not found.", e);
-
-                    if (resp.StatusCode == HttpStatusCode.Forbidden) throw new HttpException(403, "403 Not Authorized (from remote server) for : \"" + uri.ToString() + "\".", e);
-                    if (resp.StatusCode == HttpStatusCode.Moved ||
-                        resp.StatusCode == HttpStatusCode.Redirect) {
-                            if (maxRedirects < 1) throw new HttpException(500, "Too many redirects, stopped while looking for \"" + uri.ToString() + "\".");
-                            string loc = resp.GetResponseHeader("Location");
-                            if (!string.IsNullOrEmpty(loc) && Uri.IsWellFormedUriString(loc, UriKind.RelativeOrAbsolute)) {
-                                Uri newLoc = Uri.IsWellFormedUriString(loc, UriKind.Absolute) ? new Uri(loc) : new Uri(uri, new Uri(loc));
-                                response.Close(); response = null; 
-                                return GetUriStream(newLoc, maxRedirects - 1);
-                            }
-                    }
-                }
-                //if (resp != null)resp.Close();
+                HandleWebResponseException(e, uri);
                 if (response != null) response.Close();
                 throw e;
             } 
@@ -378,32 +354,34 @@ namespace ImageResizer.Plugins.RemoteReader {
         /// <returns></returns>
         public async Task<Stream> GetUriStreamAsync(Uri uri, int maxRedirects = -1)
         {
-            if (maxRedirects == -1) maxRedirects = AllowedRedirects;
-
             HttpWebResponse response = null;
-            try
-            {
-                HttpWebRequest request = (HttpWebRequest)WebRequest.Create(uri);
-                request.Timeout = 15000; //Default to 15 seconds. Browser timeout is usually 30.
-                request.AllowAutoRedirect = maxRedirects != 0;
-                request.MaximumAutomaticRedirections = maxRedirects > 0 ? maxRedirects : 0;
+            try {
                 //This is IDisposable, but only disposes the stream we are returning. So we can't dispose it, and don't need to
-                response = await request.GetResponseAsync() as HttpWebResponse;
+                response = await CreateWebRequest(uri, maxRedirects).GetResponseAsync() as HttpWebResponse;
                 return response.GetResponseStream();
-            }
-            catch (WebException e)
-            {
-                var resp = e.Response as HttpWebResponse;
-
-                if (e.Status == WebExceptionStatus.ProtocolError && resp != null)
-                {
-                    if (resp.StatusCode == HttpStatusCode.NotFound) throw new FileNotFoundException("404 error: \"" + uri.ToString() + "\" not found.", e);
-
-                    if (resp.StatusCode == HttpStatusCode.Forbidden) throw new HttpException(403, "403 Not Authorized (from remote server) for : \"" + uri.ToString() + "\".", e);
-                }
-                //if (resp != null)resp.Close();
+            } catch (WebException e) {
+                HandleWebResponseException(e, uri);
                 if (response != null) response.Close();
                 throw e;
+            }
+        }
+
+        private HttpWebRequest CreateWebRequest(Uri uri, int maxRedirects = -1) {
+            if (maxRedirects == -1) maxRedirects = AllowedRedirects;
+            HttpWebRequest request = (HttpWebRequest)WebRequest.Create(uri);
+            request.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip;
+            request.Timeout = 15000; //Default to 15 seconds. Browser timeout is usually 30.
+            request.AllowAutoRedirect = maxRedirects != 0;
+            request.MaximumAutomaticRedirections = maxRedirects > 0 ? maxRedirects : 0;
+            request.UserAgent = "ImageResizer";
+            return request;
+        }
+
+        private void HandleWebResponseException(WebException e, Uri uri) {
+            var resp = e.Response as HttpWebResponse;
+            if (e.Status == WebExceptionStatus.ProtocolError && resp != null) {
+                if (resp.StatusCode == HttpStatusCode.NotFound) throw new FileNotFoundException(String.Format("404 error: \"{0}\" not found.", uri), e);
+                if (resp.StatusCode == HttpStatusCode.Forbidden) throw new HttpException(403, String.Format("403 Not Authorized (from remote server) for : \"{0}\".", uri), e);
             }
         }
 


### PR DESCRIPTION
As explained in #234, refactors the two flavors of `GetUriStream` in the `RemoteReaderPlugin` to unify the construction of the web request, and the handling of any exceptions.

This PR also refactors the `RemoteReaderTest`: some setup is extracted to an abstract parent class, and an async sibling is added. There's wasn't much testing that actually exercised the code being changed, and none of it actually verifies the parts of the request in question (redirects, user agent, etc.). But the tests do now go down the async path, at least.