### PR TITLE
Resolve issues in PsdFile preventing PsdComposerSample from working

### DIFF
--- a/Plugins/Libs/PsdPlugin/PsdFile/Text/TdTaParser.cs
+++ b/Plugins/Libs/PsdPlugin/PsdFile/Text/TdTaParser.cs
@@ -54,7 +54,7 @@ namespace PhotoshopFile.Text
             if (m != null && m.Success)
             {
                 string key = m.Groups["key"].Value;
-                return query(((Dictionary<string,object>)tree)[key], selector.Substring(m.Length));
+                return ((Dictionary<string, object>)tree).ContainsKey(key) ? query(((Dictionary<string,object>)tree)[key], selector.Substring(m.Length)) : false;
             }
 
             //Check for array notation

--- a/Plugins/Libs/PsdPlugin/PsdFile/Text/TextLayerRenderer.cs
+++ b/Plugins/Libs/PsdPlugin/PsdFile/Text/TextLayerRenderer.cs
@@ -142,6 +142,9 @@ namespace PhotoshopFile.Text
                     fontName = new Regex("\\-(Bold|Italic|BoldItalic)$", RegexOptions.IgnoreCase | RegexOptions.IgnoreCase).Replace(fontName, "");
                     //Remove PS
                     if (fontName.EndsWith("PS")) fontName = fontName.Substring(0, fontName.Length - 2);
+                    //Convert camel case fontName to spaced font name
+                    fontName = Regex.Replace(fontName, "([a-z](?=[A-Z])|[A-Z](?=[A-Z][a-z]))", "$1 ");
+
                     //Find font family
                     try {
                         fontFamily = new FontFamily(fontName);


### PR DESCRIPTION
Need to check that a dictionary key exists in the tree object.
The font name of the psd file needs to be converted from pascal case to a spaced name in order to be correctly converted to a FontFamily. 
The PSDComposerSample now works again.