### PR TITLE
Add .NET version info to non-ASCII url warning

### DIFF
--- a/Plugins/RemoteReader/readme.md
+++ b/Plugins/RemoteReader/readme.md
@@ -107,4 +107,4 @@ In 3.1.5 and higher, spaces are supported in URLs, but to support '+' characters
 
 ## Non-ASCII URLs
 
-.NET [requires a tiny bit of configuration to allow non-ASCII characters in remote URLs](http://stackoverflow.com/questions/6107621/uri-iswellformeduristring-needs-to-be-updated).
+.NET versions prior to 4.5 require [a tiny bit of configuration to allow non-ASCII characters in remote URLs](http://stackoverflow.com/questions/6107621/uri-iswellformeduristring-needs-to-be-updated).


### PR DESCRIPTION
Update docs to reflect that IRI support is now always enabled as of .NET 4.5

per the MS docs: https://docs.microsoft.com/en-us/dotnet/api/system.uri?redirectedfrom=MSDN&view=netcore-3.1#international-resource-identifier-support